### PR TITLE
Add chmod world-writable detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ rules:
 | `tool` | any | restrict to action kinds: `shell`, `file_write`, `file_read`, `net_fetch` |
 | `shell.recursive_delete` | shell | an `rm` with a recursive flag |
 | `shell.delete_target` | shell | `sensitive` \| `outside_workspace` \| `any` |
+| `shell.chmod_world_writable` | shell | a chmod granting world-write (`777`, `o+w`, …) |
+| `shell.chmod_target` | shell | `sensitive` \| `outside_workspace` \| `any` (of a world-writable chmod) |
 | `shell.force_push` | shell | `git push --force` (not `--force-with-lease`) |
 | `shell.history_rewrite` | shell | `git reset --hard`, `git clean -fd` |
 | `shell.pipe_to_shell` | shell | a network fetch piped into a shell/interpreter |

--- a/internal/analyzer/shell/shell.go
+++ b/internal/analyzer/shell/shell.go
@@ -15,11 +15,13 @@ import (
 	"mvdan.cc/sh/v3/syntax"
 )
 
-// DeleteTarget classifies where a recursive delete is pointed.
+// DeleteTarget classifies how sensitive a path location is. It is named for its
+// first use (recursive deletes) but is a generic path-severity scale reused by
+// other detectors (e.g. chmod).
 type DeleteTarget int
 
 const (
-	// TargetNone means no delete target was found.
+	// TargetNone means no target was found.
 	TargetNone DeleteTarget = iota
 	// TargetCwdRelative is a path inside the current workspace (e.g. ./dist,
 	// node_modules, *). These are everyday operations and must not be blocked.
@@ -27,8 +29,8 @@ const (
 	// TargetOutsideWorkspace is a path that escapes the workspace but is not a
 	// well-known sensitive root (e.g. ~/.cache/foo, /tmp/x, ../sibling).
 	TargetOutsideWorkspace
-	// TargetSensitive is a home/root/system root (~, $HOME, /, /*). Deleting
-	// these recursively is almost never intentional from an agent.
+	// TargetSensitive is a home/root/system root (~, $HOME, /, /*). Touching
+	// these destructively is almost never intentional from an agent.
 	TargetSensitive
 )
 
@@ -64,6 +66,13 @@ type Analysis struct {
 	// DeleteTarget is the most severe target classification across all rm
 	// operands in the command.
 	DeleteTarget DeleteTarget
+
+	// ChmodWorldWritable is true when a chmod grants write permission to
+	// "others" (e.g. 777, 666, o+w, a+w).
+	ChmodWorldWritable bool
+	// ChmodTarget is the most severe target classification across the operands
+	// of a world-writable chmod.
+	ChmodTarget DeleteTarget
 
 	// ForcePush is true for `git push --force`/`-f` (but not --force-with-lease).
 	ForcePush bool
@@ -159,6 +168,15 @@ func (a *Analysis) inspectCommand(name string, args []string, cwd string) {
 			for _, op := range operands {
 				if t := classifyTarget(op, cwd); t > a.DeleteTarget {
 					a.DeleteTarget = t
+				}
+			}
+		}
+	case "chmod":
+		if world, paths := parseChmod(args); world {
+			a.ChmodWorldWritable = true
+			for _, p := range paths {
+				if t := classifyTarget(p, cwd); t > a.ChmodTarget {
+					a.ChmodTarget = t
 				}
 			}
 		}
@@ -311,7 +329,101 @@ func parseRmFlags(args []string) (recursive, forced bool, operands []string) {
 	return recursive, forced, operands
 }
 
-// classifyTarget decides how dangerous a single rm operand is.
+// parseChmod splits chmod arguments into the mode and its target paths, then
+// reports whether the mode grants world-write. The mode is the first non-option
+// token; `--reference=FILE` copies a mode from elsewhere and is treated as not
+// world-writable (nothing to classify).
+func parseChmod(args []string) (world bool, paths []string) {
+	mode := ""
+	sawMode := false
+	for _, arg := range args {
+		if !sawMode {
+			switch {
+			case arg == "--":
+				continue
+			case strings.HasPrefix(arg, "--reference"):
+				return false, nil
+			case strings.HasPrefix(arg, "--"):
+				continue // long option (--recursive, --verbose, ...)
+			case strings.HasPrefix(arg, "-") && len(arg) > 1 && !isRemovalMode(arg):
+				continue // short option flags (-R, -Rv, -v, ...)
+			}
+			mode = arg
+			sawMode = true
+			continue
+		}
+		paths = append(paths, arg)
+	}
+	if !sawMode {
+		return false, nil
+	}
+	return chmodWorldWritable(mode), paths
+}
+
+// isRemovalMode reports whether a `-`-prefixed token is a symbolic *mode* that
+// removes permissions (e.g. `-w`, `-rx`) rather than an option flag (`-R`).
+// Removal modes never grant world-write, but they must not be skipped as flags.
+func isRemovalMode(arg string) bool {
+	if len(arg) < 2 || arg[0] != '-' {
+		return false
+	}
+	for _, c := range arg[1:] {
+		if !strings.ContainsRune("rwxXst", c) {
+			return false
+		}
+	}
+	return true
+}
+
+// chmodWorldWritable reports whether a chmod mode grants write to "others".
+func chmodWorldWritable(mode string) bool {
+	if mode == "" {
+		return false
+	}
+	if isOctalMode(mode) {
+		// The last octal digit is the "others" class; the write bit is 2.
+		last := mode[len(mode)-1] - '0'
+		return last&2 != 0
+	}
+	for _, clause := range strings.Split(mode, ",") {
+		if symbolicGrantsWorldWrite(clause) {
+			return true
+		}
+	}
+	return false
+}
+
+func isOctalMode(s string) bool {
+	if s == "" || len(s) > 4 {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '7' {
+			return false
+		}
+	}
+	return true
+}
+
+// symbolicGrantsWorldWrite reports whether a single symbolic clause (e.g.
+// `o+w`, `a+rwx`, `+w`) adds write permission for others or all.
+func symbolicGrantsWorldWrite(clause string) bool {
+	i := strings.IndexAny(clause, "+-=")
+	if i < 0 {
+		return false
+	}
+	who, op, perms := clause[:i], clause[i], clause[i+1:]
+	if op == '-' { // removing permissions
+		return false
+	}
+	if !strings.ContainsRune(perms, 'w') {
+		return false
+	}
+	// An empty "who" means all (a); otherwise it must include others or all.
+	return who == "" || strings.ContainsRune(who, 'o') || strings.ContainsRune(who, 'a')
+}
+
+// classifyTarget decides how sensitive a single path operand is.
 func classifyTarget(target, cwd string) DeleteTarget {
 	t := strings.TrimSpace(target)
 	if t == "" {

--- a/internal/analyzer/shell/shell_test.go
+++ b/internal/analyzer/shell/shell_test.go
@@ -115,3 +115,45 @@ func TestPipeToShellFromNet(t *testing.T) {
 		})
 	}
 }
+
+func TestChmodFacts(t *testing.T) {
+	const cwd = "/Users/dev/project"
+	cases := []struct {
+		name    string
+		command string
+		world   bool
+		target  DeleteTarget
+	}{
+		// World-writable on sensitive roots.
+		{"recursive 777 home", "chmod -R 777 ~", true, TargetSensitive},
+		{"777 root", "chmod 777 /", true, TargetSensitive},
+		{"a+rwx home", "chmod -R a+rwx $HOME", true, TargetSensitive},
+		// World-writable elsewhere.
+		{"777 etc passwd", "chmod 777 /etc/passwd", true, TargetOutsideWorkspace},
+		{"666 tmp", "chmod 666 /tmp/x", true, TargetOutsideWorkspace},
+		{"777 local file", "chmod 777 ./script.sh", true, TargetCwdRelative},
+		{"o+w local", "chmod o+w config.yaml", true, TargetCwdRelative},
+		{"combined flags then mode", "chmod -Rv 777 build", true, TargetCwdRelative},
+		// Not world-writable -> no fact (no false positives).
+		{"add execute", "chmod +x script.sh", false, TargetNone},
+		{"644", "chmod 644 file", false, TargetNone},
+		{"755 recursive", "chmod -R 755 dir", false, TargetNone},
+		{"600 key", "chmod 600 ~/.ssh/id_rsa", false, TargetNone},
+		{"remove world write", "chmod o-w file", false, TargetNone},
+		{"owner write only", "chmod u+w file", false, TargetNone},
+		{"group write only", "chmod g+w file", false, TargetNone},
+		{"not chmod", "ls -la", false, TargetNone},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := Analyze(tc.command, cwd)
+			if a.ChmodWorldWritable != tc.world {
+				t.Errorf("ChmodWorldWritable = %v, want %v", a.ChmodWorldWritable, tc.world)
+			}
+			if a.ChmodTarget != tc.target {
+				t.Errorf("ChmodTarget = %v, want %v", a.ChmodTarget, tc.target)
+			}
+		})
+	}
+}

--- a/internal/policy/builtin/recommended.yaml
+++ b/internal/policy/builtin/recommended.yaml
@@ -34,6 +34,29 @@ rules:
         recursive_delete: true
         delete_target: outside_workspace
 
+  - id: chmod-world-writable-sensitive
+    description: Making home, root, or a system location world-writable
+    severity: critical
+    effect: deny
+    message: >-
+      Leash blocked a chmod that makes a sensitive location (home, root, or a
+      system path) world-writable. This is almost never intended.
+    match:
+      shell:
+        chmod_world_writable: true
+        chmod_target: sensitive
+
+  - id: chmod-world-writable
+    description: Making files world-writable (chmod 777 / o+w)
+    severity: medium
+    effect: ask
+    message: >-
+      This makes files world-writable — anyone on the machine can modify them.
+      Confirm this is intended.
+    match:
+      shell:
+        chmod_world_writable: true
+
   - id: pipe-to-shell-from-network
     description: Piping a network download directly into a shell or interpreter
     severity: high

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -102,21 +102,14 @@ func matchShell(m *ShellMatch, a *shell.Analysis) bool {
 	if m.RecursiveDelete && !a.RecursiveDelete {
 		return false
 	}
-	if m.DeleteTarget != "" {
-		switch m.DeleteTarget {
-		case "any":
-			if a.DeleteTarget == shell.TargetNone {
-				return false
-			}
-		case "sensitive":
-			if a.DeleteTarget != shell.TargetSensitive {
-				return false
-			}
-		case "outside_workspace":
-			if a.DeleteTarget != shell.TargetOutsideWorkspace {
-				return false
-			}
-		}
+	if m.DeleteTarget != "" && !targetMatches(m.DeleteTarget, a.DeleteTarget) {
+		return false
+	}
+	if m.ChmodWorldWritable && !a.ChmodWorldWritable {
+		return false
+	}
+	if m.ChmodTarget != "" && !targetMatches(m.ChmodTarget, a.ChmodTarget) {
+		return false
 	}
 	if m.ForcePush && !a.ForcePush {
 		return false
@@ -129,6 +122,21 @@ func matchShell(m *ShellMatch, a *shell.Analysis) bool {
 	}
 	if len(m.CommandIn) > 0 && !a.Has(m.CommandIn...) {
 		return false
+	}
+	return true
+}
+
+// targetMatches reports whether a path-severity spec
+// (sensitive|outside_workspace|any) is satisfied by the analyzed target.
+// Unknown specs are rejected at load time, so they pass here.
+func targetMatches(spec string, t shell.DeleteTarget) bool {
+	switch spec {
+	case "any":
+		return t != shell.TargetNone
+	case "sensitive":
+		return t == shell.TargetSensitive
+	case "outside_workspace":
+		return t == shell.TargetOutsideWorkspace
 	}
 	return true
 }

--- a/internal/policy/engine_test.go
+++ b/internal/policy/engine_test.go
@@ -108,3 +108,43 @@ func TestDenyOverridesAsk(t *testing.T) {
 		t.Errorf("matched %d rules, want 2", len(d.Matched))
 	}
 }
+
+func TestRecommendedChmodDecisions(t *testing.T) {
+	e := recommendedEngine(t)
+	const cwd = "/Users/dev/project"
+
+	cases := []struct {
+		command string
+		want    Effect
+		rule    string
+	}{
+		// World-writable on sensitive roots -> deny.
+		{"chmod -R 777 ~", EffectDeny, "chmod-world-writable-sensitive"},
+		{"chmod 777 /", EffectDeny, "chmod-world-writable-sensitive"},
+		// World-writable elsewhere -> ask.
+		{"chmod 777 /etc/passwd", EffectAsk, "chmod-world-writable"},
+		{"chmod 777 ./script.sh", EffectAsk, "chmod-world-writable"},
+		{"chmod -R o+w build", EffectAsk, "chmod-world-writable"},
+		// Not world-writable -> allow (no false positives).
+		{"chmod +x deploy.sh", EffectAllow, ""},
+		{"chmod 644 config.json", EffectAllow, ""},
+		{"chmod -R 755 public", EffectAllow, ""},
+		{"chmod 600 ~/.ssh/id_rsa", EffectAllow, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.command, func(t *testing.T) {
+			d := e.Evaluate(Action{Kind: ActionShell, Command: tc.command, Cwd: cwd})
+			if d.Effect != tc.want {
+				t.Fatalf("Effect = %q, want %q", d.Effect, tc.want)
+			}
+			gotRule := ""
+			if d.Rule != nil {
+				gotRule = d.Rule.ID
+			}
+			if gotRule != tc.rule {
+				t.Errorf("deciding rule = %q, want %q", gotRule, tc.rule)
+			}
+		})
+	}
+}

--- a/internal/policy/rule.go
+++ b/internal/policy/rule.go
@@ -44,12 +44,14 @@ type Match struct {
 
 // ShellMatch matches against facts produced by the shell analyzer.
 type ShellMatch struct {
-	RecursiveDelete bool     `yaml:"recursive_delete,omitempty"`
-	DeleteTarget    string   `yaml:"delete_target,omitempty"` // sensitive|outside_workspace|any
-	ForcePush       bool     `yaml:"force_push,omitempty"`
-	HistoryRewrite  bool     `yaml:"history_rewrite,omitempty"`
-	PipeToShell     bool     `yaml:"pipe_to_shell,omitempty"`
-	CommandIn       []string `yaml:"command_in,omitempty"`
+	RecursiveDelete    bool     `yaml:"recursive_delete,omitempty"`
+	DeleteTarget       string   `yaml:"delete_target,omitempty"` // sensitive|outside_workspace|any
+	ChmodWorldWritable bool     `yaml:"chmod_world_writable,omitempty"`
+	ChmodTarget        string   `yaml:"chmod_target,omitempty"` // sensitive|outside_workspace|any
+	ForcePush          bool     `yaml:"force_push,omitempty"`
+	HistoryRewrite     bool     `yaml:"history_rewrite,omitempty"`
+	PipeToShell        bool     `yaml:"pipe_to_shell,omitempty"`
+	CommandIn          []string `yaml:"command_in,omitempty"`
 }
 
 func (m Match) isEmpty() bool {
@@ -68,11 +70,12 @@ func (r *Rule) compile() error {
 	if r.Match.isEmpty() {
 		return fmt.Errorf("rule %q has an empty match (would never fire)", r.ID)
 	}
-	if dt := r.Match.Shell; dt != nil && dt.DeleteTarget != "" {
-		switch dt.DeleteTarget {
-		case "sensitive", "outside_workspace", "any":
-		default:
-			return fmt.Errorf("rule %q has invalid delete_target %q", r.ID, dt.DeleteTarget)
+	if sh := r.Match.Shell; sh != nil {
+		if err := validateTargetSpec(r.ID, "delete_target", sh.DeleteTarget); err != nil {
+			return err
+		}
+		if err := validateTargetSpec(r.ID, "chmod_target", sh.ChmodTarget); err != nil {
+			return err
 		}
 	}
 	if r.Match.Regex != "" {
@@ -90,4 +93,13 @@ func (r *Rule) compile() error {
 		r.url = re
 	}
 	return nil
+}
+
+func validateTargetSpec(ruleID, field, spec string) error {
+	switch spec {
+	case "", "sensitive", "outside_workspace", "any":
+		return nil
+	default:
+		return fmt.Errorf("rule %q has invalid %s %q", ruleID, field, spec)
+	}
 }


### PR DESCRIPTION
## What

Adds the **chmod world-writable** detector. Leash now flags `chmod` commands that grant write permission to "others" — making files modifiable by anyone on the machine.

```
chmod -R 777 ~            → DENY   (sensitive root)
chmod 777 /etc/passwd     → ASK
chmod 777 ./script.sh     → ASK
chmod +x deploy.sh        → ALLOW
chmod -R 755 public       → ALLOW
chmod 600 ~/.ssh/id_rsa   → ALLOW
```

## How

Same extend-pattern — analyzer facts, predicates, two rules — plus a small refactor: the path-severity check is now a shared `targetMatches` helper used by both the delete and chmod detectors.

- **`internal/analyzer/shell`** — `ChmodWorldWritable` + `ChmodTarget` facts. `chmodWorldWritable` understands octal modes (the world-write bit on the "others" digit) and symbolic modes (`o+w`, `a+rwx`, `+w`); `parseChmod` separates option flags (`-R`, `-Rv`) from the mode, including removal modes like `-w`.
- **`internal/policy`** — `shell.chmod_world_writable` + `shell.chmod_target` predicates; `matchShell` via the shared `targetMatches`.
- **`recommended.yaml`** — `chmod-world-writable-sensitive` (**deny**) + `chmod-world-writable` (**ask**). Tiering falls out of deny-overrides, same as the delete rules.

## Decisions

- **Tiered**: deny only on sensitive roots (home/root/system); ask everywhere else (`chmod 777` on a local file is bad practice but sometimes intended).
- Keyed on the **world-write bit**, so `chmod +x`, `755`, `644`, `600`, and owner/group-only writes are never flagged.

## Tests

16 analyzer cases + 9 decision cases, including false-positive guards. `go test ./...` green; `gofmt`/`vet` clean.

## Notes

- Branches off `main` independently of #1 (exfil); they touch adjacent code at different anchors and merge cleanly.
- README roadmap line left untouched to avoid colliding with #1; will reconcile on merge.

Closes ATR-11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
