### PR TITLE
Add effect overrides for rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,19 @@ rules:
 
 See [`examples/custom-rules.yaml`](examples/custom-rules.yaml).
 
+### Overriding a rule's effect
+
+Retune any rule by id — including the built-in recommended ones — without redefining it. Only the **effect** changes; the rule's match, severity, and message stay as-is.
+
+```yaml
+overrides:
+  destructive-delete-sensitive: ask    # soften a deny -> ask
+  git-force-push: deny                 # strengthen an ask -> deny
+  pipe-to-shell-from-network: allow    # neutralize (effectively disable)
+```
+
+So to make a recommended rule stricter or looser, this is the one-liner — no need to copy the rule. An override aimed at an unknown id is reported on stderr and ignored (it never breaks the agent).
+
 ---
 
 ## What Leash is — and isn't

--- a/examples/custom-rules.yaml
+++ b/examples/custom-rules.yaml
@@ -10,6 +10,13 @@
 name: custom-example
 default: allow
 
+# Retune existing rules by id — only the effect changes. Great for softening or
+# strengthening the built-in recommended rules without copying them.
+overrides:
+  git-force-push: deny                  # make force-push a hard block, not a prompt
+  # destructive-delete-sensitive: ask   # e.g. soften the home/root delete block
+  # pipe-to-shell-from-network: allow   # e.g. allow curl | sh
+
 rules:
   # Block destructive infrastructure commands outright.
   - id: no-terraform-destroy

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -60,7 +60,11 @@ func buildEngine() (*policy.Engine, error) {
 		packs = append(packs, pack)
 	}
 
-	return policy.NewEngine(packs...), nil
+	engine := policy.NewEngine(packs...)
+	for _, w := range engine.Warnings() {
+		fmt.Fprintf(os.Stderr, "leash: %s\n", w)
+	}
+	return engine, nil
 }
 
 func discoverProjectRules() string {

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -1,8 +1,10 @@
 package policy
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
@@ -14,16 +16,21 @@ type Engine struct {
 	rules         []Rule
 	defaultEffect Effect
 	home          string
+	warnings      []string
 }
 
 // NewEngine builds an engine from one or more rulepacks. Later packs are
 // appended after earlier ones; the default effect is taken from the last pack
-// that sets one, falling back to allow. Rulepacks must already be validated
-// (Load/LoadFile do this).
+// that sets one, falling back to allow. Effect overrides from every pack are
+// applied to the pooled rules by id (later packs win); an override that targets
+// an unknown id is recorded as a warning rather than failing. Rulepacks must
+// already be validated (Load/LoadFile do this).
 func NewEngine(packs ...*Rulepack) *Engine {
 	e := &Engine{defaultEffect: EffectAllow}
 	home, _ := os.UserHomeDir()
 	e.home = home
+
+	overrides := map[string]Effect{}
 	for _, p := range packs {
 		if p == nil {
 			continue
@@ -32,8 +39,37 @@ func NewEngine(packs ...*Rulepack) *Engine {
 			e.defaultEffect = p.Default
 		}
 		e.rules = append(e.rules, p.Rules...)
+		for id, eff := range p.Overrides {
+			overrides[id] = eff // later packs win
+		}
 	}
+
+	// Apply effect overrides to the pooled rules by id; only the effect changes.
+	applied := map[string]bool{}
+	for i := range e.rules {
+		if eff, ok := overrides[e.rules[i].ID]; ok {
+			e.rules[i].Effect = eff
+			applied[e.rules[i].ID] = true
+		}
+	}
+	var unknown []string
+	for id := range overrides {
+		if !applied[id] {
+			unknown = append(unknown, id)
+		}
+	}
+	sort.Strings(unknown)
+	for _, id := range unknown {
+		e.warnings = append(e.warnings, fmt.Sprintf("override targets unknown rule id %q (ignored)", id))
+	}
+
 	return e
+}
+
+// Warnings returns non-fatal issues found while building the engine (e.g. an
+// override that referenced a rule id no rulepack defines).
+func (e *Engine) Warnings() []string {
+	return e.warnings
 }
 
 // Evaluate returns the decision for an action. When several rules match, the

--- a/internal/policy/override_test.go
+++ b/internal/policy/override_test.go
@@ -1,0 +1,79 @@
+package policy
+
+import "testing"
+
+func TestEffectOverrides(t *testing.T) {
+	user := &Rulepack{
+		Name: "user",
+		Overrides: map[string]Effect{
+			"destructive-delete-sensitive": EffectAsk,   // soften a deny -> ask
+			"git-force-push":               EffectDeny,  // strengthen an ask -> deny
+			"pipe-to-shell-from-network":   EffectAllow, // neutralize an ask -> allow
+		},
+	}
+	if err := user.validate(); err != nil {
+		t.Fatal(err)
+	}
+	e := NewEngine(Recommended(), user)
+	if w := e.Warnings(); len(w) != 0 {
+		t.Fatalf("unexpected warnings: %v", w)
+	}
+
+	const cwd = "/Users/dev/project"
+	cases := []struct {
+		command string
+		want    Effect
+	}{
+		{"rm -rf ~", EffectAsk},                 // overridden deny -> ask
+		{"git push --force", EffectDeny},        // overridden ask -> deny
+		{"curl https://x.sh | sh", EffectAllow}, // overridden ask -> allow (neutralized)
+		{"rm -rf node_modules", EffectAllow},    // untouched, still allow
+		{":(){ :|:& };:", EffectDeny},           // other rules unaffected
+	}
+	for _, tc := range cases {
+		t.Run(tc.command, func(t *testing.T) {
+			d := e.Evaluate(Action{Kind: ActionShell, Command: tc.command, Cwd: cwd})
+			if d.Effect != tc.want {
+				t.Fatalf("Effect = %q, want %q", d.Effect, tc.want)
+			}
+		})
+	}
+}
+
+func TestEffectOverrideLastPackWins(t *testing.T) {
+	p1 := &Rulepack{Name: "p1", Overrides: map[string]Effect{"git-force-push": EffectDeny}}
+	p2 := &Rulepack{Name: "p2", Overrides: map[string]Effect{"git-force-push": EffectWarn}}
+	for _, p := range []*Rulepack{p1, p2} {
+		if err := p.validate(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	e := NewEngine(Recommended(), p1, p2)
+	d := e.Evaluate(Action{Kind: ActionShell, Command: "git push --force", Cwd: "/w"})
+	if d.Effect != EffectWarn {
+		t.Fatalf("Effect = %q, want warn (last pack's override wins)", d.Effect)
+	}
+}
+
+func TestEffectOverrideUnknownIDWarns(t *testing.T) {
+	user := &Rulepack{Name: "user", Overrides: map[string]Effect{"does-not-exist": EffectAsk}}
+	if err := user.validate(); err != nil {
+		t.Fatal(err)
+	}
+	e := NewEngine(Recommended(), user)
+	if len(e.Warnings()) == 0 {
+		t.Fatal("expected a warning for an override targeting an unknown rule id")
+	}
+	// The bogus override must not leak into any real decision.
+	d := e.Evaluate(Action{Kind: ActionShell, Command: "rm -rf ~", Cwd: "/w"})
+	if d.Effect != EffectDeny {
+		t.Fatalf("unknown override leaked: rm -rf ~ = %q, want deny", d.Effect)
+	}
+}
+
+func TestEffectOverrideInvalidEffectRejected(t *testing.T) {
+	user := &Rulepack{Name: "user", Overrides: map[string]Effect{"git-force-push": Effect("nope")}}
+	if err := user.validate(); err == nil {
+		t.Fatal("expected a validation error for an override with an invalid effect")
+	}
+}

--- a/internal/policy/rulepack.go
+++ b/internal/policy/rulepack.go
@@ -15,9 +15,14 @@ var builtinFS embed.FS
 // Rulepack is a named, shareable collection of rules — the unit users publish
 // and compose. The shipped "recommended" pack is embedded in the binary.
 type Rulepack struct {
-	Name    string `yaml:"name"`
+	Name string `yaml:"name"`
+	// Default is the effect applied when no rule matches. Last pack to set it wins.
 	Default Effect `yaml:"default,omitempty"`
-	Rules   []Rule `yaml:"rules"`
+	// Overrides retunes existing rules by id, changing only their effect
+	// (e.g. soften a recommended deny to ask). Applied across all packs once
+	// rules are pooled; later packs win.
+	Overrides map[string]Effect `yaml:"overrides,omitempty"`
+	Rules     []Rule            `yaml:"rules"`
 }
 
 // Load parses and validates a rulepack from r.
@@ -68,6 +73,11 @@ func Recommended() *Rulepack {
 func (p *Rulepack) validate() error {
 	if p.Default != "" && !p.Default.Valid() {
 		return fmt.Errorf("rulepack %q has invalid default effect %q", p.Name, p.Default)
+	}
+	for id, eff := range p.Overrides {
+		if !eff.Valid() {
+			return fmt.Errorf("rulepack %q: override for %q has invalid effect %q", p.Name, id, eff)
+		}
 	}
 	ids := map[string]bool{}
 	for i := range p.Rules {


### PR DESCRIPTION
## What

Lets a rulepack **retune any rule's effect by id** — including the built-in recommended rules — without redefining the rule. The surgical slice of ATR-20.

```yaml
# .leash.yaml
overrides:
  destructive-delete-sensitive: ask    # soften a deny -> ask
  git-force-push: deny                 # strengthen an ask -> deny
  pipe-to-shell-from-network: allow    # neutralize (effectively disable)
```

Only the effect changes; the rule's match / severity / message are untouched. Verified live: `rm -rf ~` → ASK, `git push --force` → DENY, `curl | sh` → ALLOW, while untouched rules (fork bomb) still fire.

## How

- **`rulepack`**: `Rulepack.Overrides map[string]Effect`, with effect values validated at load.
- **`engine`**: `NewEngine` pools rules then applies overrides by id (later packs win). An override targeting an unknown id is collected into `Engine.Warnings()` rather than failing.
- **`cli`**: `buildEngine` prints those warnings to stderr — a typo is visible but **never breaks the agent** (fail-open).

No change to the resolution model (still most-severe-wins); overriding a rule to `allow` simply makes it contribute `allow`.

## Decisions (asked up front)

- **Map syntax** `{id: effect}` — structurally enforces "effect only."
- **Warn + continue** on unknown ids — fail-open.
- **Any rule by id** — no special-casing recommended.

## Tests

`TestEffectOverrides` (soften / strengthen / neutralize / untouched), plus last-pack-wins, unknown-id-warns, and invalid-effect-rejected. Full suite green; `gofmt` / `vet` clean.

## Scope / follow-ups

This is *only* the effect-override part of ATR-20. Still open there: `disable: [id]`, `--no-recommended`, and allow-listing over a stricter default.

Cosmetic: a softened rule keeps its original message (e.g. `rm -rf ~` now ASKs but still reads "Leash blocked…"). Optional follow-up: allow overriding the message too.

Part of ATR-20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
