### PR TITLE
Add dd/mkfs block-device detector

### DIFF
--- a/internal/analyzer/shell/shell.go
+++ b/internal/analyzer/shell/shell.go
@@ -10,6 +10,7 @@ package shell
 
 import (
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"mvdan.cc/sh/v3/syntax"
@@ -98,6 +99,12 @@ type Analysis struct {
 	// ChmodTarget is the most severe target classification across the operands
 	// of a world-writable chmod.
 	ChmodTarget DeleteTarget
+
+	// BlockDeviceWrite is true when a command writes destructively to a raw
+	// disk / block device: `dd of=/dev/sdX`, `mkfs` on a device, or a shell
+	// redirect to one. Pseudo-devices (/dev/null, /dev/zero, /dev/stdout) and
+	// regular image files never count, so cloning to an .img is not flagged.
+	BlockDeviceWrite bool
 
 	// ForcePush is true for `git push --force`/`-f` (but not --force-with-lease).
 	ForcePush bool
@@ -188,10 +195,15 @@ func Analyze(command, cwd string) Analysis {
 				a.NetEgress = true
 			}
 		case *syntax.Redirect:
-			// `cat secret > /dev/tcp/host/port` opens a network socket.
+			// A redirect target can open a network socket (`> /dev/tcp/host/port`)
+			// or write onto a raw disk (`cat img > /dev/sda`).
 			if n.Word != nil {
-				if txt, _ := wordToString(n.Word); isDevNet(txt) {
+				txt, _ := wordToString(n.Word)
+				if isDevNet(txt) {
 					a.NetEgress = true
+				}
+				if isOutputRedirect(n.Op) && isBlockDevice(txt) {
+					a.BlockDeviceWrite = true
 				}
 			}
 		case *syntax.BinaryCmd:
@@ -235,6 +247,24 @@ func (a *Analysis) inspectCommand(name string, args []string, cwd string) {
 		}
 	case "git":
 		a.inspectGit(args)
+	case "dd":
+		// dd writes to the file named by its `of=` operand. Flag only when that
+		// target is a real block device — never /dev/null, /dev/zero, or a
+		// regular image file (cloning a disk *to* a file is safe).
+		for _, arg := range args {
+			if dev, ok := strings.CutPrefix(arg, "of="); ok && isBlockDevice(dev) {
+				a.BlockDeviceWrite = true
+			}
+		}
+	}
+	// mkfs / mkfs.<fstype> formats whichever device path it is handed; making a
+	// filesystem in an image file (a non-/dev path) is left alone.
+	if name == "mkfs" || strings.HasPrefix(name, "mkfs.") {
+		for _, arg := range args {
+			if !strings.HasPrefix(arg, "-") && isBlockDevice(arg) {
+				a.BlockDeviceWrite = true
+			}
+		}
 	}
 }
 
@@ -679,6 +709,38 @@ func hasListenFlag(args []string) bool {
 // used to open a raw network connection (e.g. `cat secret > /dev/tcp/host/port`).
 func isDevNet(word string) bool {
 	return strings.Contains(word, "/dev/tcp/") || strings.Contains(word, "/dev/udp/")
+}
+
+// blockDeviceRe matches a raw disk or partition node under /dev — the kind of
+// target a destructive dd/mkfs write (or redirect) would irreversibly wipe. It
+// spans Linux (sd/hd/vd/xvd disks, nvme, mmcblk) and macOS (disk/rdisk).
+// Pseudo-devices such as /dev/null, /dev/zero, /dev/random and /dev/stdout
+// deliberately do NOT match, so writing to a bit bucket or an image file is
+// never flagged.
+var blockDeviceRe = regexp.MustCompile(`^/dev/(` +
+	`(s|h|v|xv)d[a-z]+[0-9]*` + // sda, sdb1, hda, vda, xvda2
+	`|nvme[0-9]+n[0-9]+(p[0-9]+)?` + // nvme0n1, nvme0n1p2
+	`|mmcblk[0-9]+(p[0-9]+)?` + // mmcblk0, mmcblk0p1
+	`|r?disk[0-9]+(s[0-9]+)*` + // macOS disk2, rdisk2, disk0s1
+	`)$`)
+
+// isBlockDevice reports whether path names a raw disk / block-device node that a
+// destructive write would wipe. The word is already resolved from the AST (a dd
+// `of=` value, an mkfs operand, or a redirect target), so this is a semantic
+// classification of that path — not a substring scan of the raw command.
+func isBlockDevice(path string) bool {
+	return blockDeviceRe.MatchString(strings.TrimSpace(path))
+}
+
+// isOutputRedirect reports whether a redirect operator writes to its target
+// (`>`, `>>`, `>|`, `&>`, `&>>`) rather than reading from it. Input and
+// here-doc redirects can never wipe a device, so they are excluded.
+func isOutputRedirect(op syntax.RedirOperator) bool {
+	switch op {
+	case syntax.RdrOut, syntax.AppOut, syntax.ClbOut, syntax.RdrAll, syntax.AppAll:
+		return true
+	}
+	return false
 }
 
 // wordToString reconstructs the textual value of a word. Parameter expansions

--- a/internal/analyzer/shell/shell_test.go
+++ b/internal/analyzer/shell/shell_test.go
@@ -158,6 +158,60 @@ func TestChmodFacts(t *testing.T) {
 	}
 }
 
+func TestBlockDeviceWrite(t *testing.T) {
+	cases := []struct {
+		name    string
+		command string
+		want    bool
+	}{
+		// dd writing to a real block device.
+		{"dd to sda", "dd if=x of=/dev/sda", true},
+		{"dd to disk2", "dd of=/dev/disk2 bs=1m", true},
+		{"dd zero to nvme", "dd if=/dev/zero of=/dev/nvme0n1", true},
+		{"dd to sd partition", "dd if=img of=/dev/sdb1", true},
+		{"dd to mmcblk", "dd if=backup.img of=/dev/mmcblk0", true},
+		{"sudo dd to rdisk", "sudo dd if=image.iso of=/dev/rdisk3 bs=1m", true},
+		{"dd to xen disk", "dd if=/dev/zero of=/dev/xvda", true},
+		// mkfs formatting a device.
+		{"mkfs.ext4 partition", "mkfs.ext4 /dev/sdb1", true},
+		{"mkfs -t device", "mkfs -t ext4 /dev/sdb", true},
+		{"mkfs.vfat macos slice", "mkfs.vfat /dev/disk2s1", true},
+		{"mkfs with label flag", "mkfs.ext4 -L data /dev/vdb", true},
+		// Raw redirects onto a block device.
+		{"redirect to sda", "cat image.iso > /dev/sda", true},
+		{"append to sdb", "echo x >> /dev/sdb", true},
+
+		// dd/redirect to a pseudo-device or file — safe, must not flag.
+		{"dd to image file", "dd if=/dev/zero of=disk.img bs=1M count=100", false},
+		{"dd to null", "dd of=/dev/null", false},
+		{"dd file to file", "dd if=in.iso of=out.iso", false},
+		{"dd reading disk to file", "dd if=/dev/sda of=backup.img", false},
+		{"dd urandom to file", "dd if=/dev/urandom of=random.bin bs=1M count=1", false},
+		{"mkfs on image file", "mkfs.ext4 disk.img", false},
+		{"mkfs on relative image", "mkfs -t ext4 ./fs.img", false},
+		{"redirect to null", "cat foo > /dev/null", false},
+		{"redirect to file", "echo hi > output.txt", false},
+		{"stderr to null", "make 2>/dev/null", false},
+		// Reading from a disk is not a destructive write.
+		{"cat a disk", "cat /dev/sda", false},
+		{"clone disk out via pipe", "dd if=/dev/sda | gzip > disk.img.gz", false},
+		// Not dd/mkfs at all.
+		{"list", "ls -la", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := Analyze(tc.command, "/Users/dev/project")
+			if !a.Parsed {
+				t.Fatalf("command did not parse: %q", tc.command)
+			}
+			if a.BlockDeviceWrite != tc.want {
+				t.Errorf("BlockDeviceWrite = %v, want %v", a.BlockDeviceWrite, tc.want)
+			}
+		})
+	}
+}
+
 func TestSecretExfiltration(t *testing.T) {
 	cases := []struct {
 		name    string

--- a/internal/policy/builtin/recommended.yaml
+++ b/internal/policy/builtin/recommended.yaml
@@ -57,6 +57,19 @@ rules:
       shell:
         chmod_world_writable: true
 
+  - id: destructive-disk-write
+    description: Destructive write to a raw disk or block device (dd, mkfs, or redirect)
+    severity: critical
+    effect: deny
+    message: >-
+      Leash blocked a destructive write to a raw disk or block device (via dd,
+      mkfs, or a redirect to /dev/sd*, /dev/nvme*, /dev/disk*, …). This wipes the
+      target irreversibly and is almost never intended from an agent. If you
+      really mean it, run the command yourself.
+    match:
+      shell:
+        block_device_write: true
+
   - id: pipe-to-shell-from-network
     description: Piping a network download directly into a shell or interpreter
     severity: high

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -147,6 +147,9 @@ func matchShell(m *ShellMatch, a *shell.Analysis) bool {
 	if m.ChmodTarget != "" && !targetMatches(m.ChmodTarget, a.ChmodTarget) {
 		return false
 	}
+	if m.BlockDeviceWrite && !a.BlockDeviceWrite {
+		return false
+	}
 	if m.ForcePush && !a.ForcePush {
 		return false
 	}

--- a/internal/policy/engine_test.go
+++ b/internal/policy/engine_test.go
@@ -149,6 +149,44 @@ func TestRecommendedChmodDecisions(t *testing.T) {
 	}
 }
 
+func TestRecommendedBlockDeviceDecisions(t *testing.T) {
+	e := recommendedEngine(t)
+	const cwd = "/Users/dev/project"
+
+	cases := []struct {
+		command string
+		want    Effect
+		rule    string
+	}{
+		// Destructive disk writes -> deny.
+		{"dd if=/dev/zero of=/dev/sda", EffectDeny, "destructive-disk-write"},
+		{"mkfs.ext4 /dev/sdb1", EffectDeny, "destructive-disk-write"},
+		{"sudo dd if=x of=/dev/disk2 bs=1m", EffectDeny, "destructive-disk-write"},
+		{"cat image.iso > /dev/sda", EffectDeny, "destructive-disk-write"},
+		// Writing to an image file or bit bucket -> allow (no false positives).
+		{"dd if=/dev/zero of=disk.img bs=1M count=100", EffectAllow, ""},
+		{"dd of=/dev/null", EffectAllow, ""},
+		{"dd if=in.iso of=out.iso", EffectAllow, ""},
+		{"mkfs.ext4 backup.img", EffectAllow, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.command, func(t *testing.T) {
+			d := e.Evaluate(Action{Kind: ActionShell, Command: tc.command, Cwd: cwd})
+			if d.Effect != tc.want {
+				t.Fatalf("Effect = %q, want %q", d.Effect, tc.want)
+			}
+			gotRule := ""
+			if d.Rule != nil {
+				gotRule = d.Rule.ID
+			}
+			if gotRule != tc.rule {
+				t.Errorf("deciding rule = %q, want %q", gotRule, tc.rule)
+			}
+		})
+	}
+}
+
 func TestRecommendedExfilDecisions(t *testing.T) {
 	e := recommendedEngine(t)
 	const cwd = "/Users/dev/project"

--- a/internal/policy/rule.go
+++ b/internal/policy/rule.go
@@ -48,6 +48,7 @@ type ShellMatch struct {
 	DeleteTarget       string   `yaml:"delete_target,omitempty"` // sensitive|outside_workspace|any
 	ChmodWorldWritable bool     `yaml:"chmod_world_writable,omitempty"`
 	ChmodTarget        string   `yaml:"chmod_target,omitempty"` // sensitive|outside_workspace|any
+	BlockDeviceWrite   bool     `yaml:"block_device_write,omitempty"`
 	ForcePush          bool     `yaml:"force_push,omitempty"`
 	HistoryRewrite     bool     `yaml:"history_rewrite,omitempty"`
 	PipeToShell        bool     `yaml:"pipe_to_shell,omitempty"`


### PR DESCRIPTION
Detects destructive writes to a raw disk / block device — the class of command that irreversibly wipes a drive — and denies them in the `recommended` pack. Closes ATR-12.

## What it catches

Semantic detection (analyzer fact + `Match` predicate, **not** a substring denylist — so `sudo`, flag reordering, and quoting don't evade it):

- **`dd`** — flagged only when the `of=` operand is a real block device: `/dev/sd*`, `/dev/nvme*`, `/dev/mmcblk*`, macOS `/dev/disk*`/`/dev/rdisk*`, and virtio/Xen `vd*`/`xvd*`.
- **`mkfs` / `mkfs.*`** — flagged when handed a device path (`mkfs.ext4 /dev/sdb1`).
- **output redirects** — `cat img > /dev/sda` and `>> /dev/sdb`.

Effect is **`deny`**: writing to a raw disk is almost never legitimate from an agent.

## Near-zero false positives (the product thesis)

All of these stay **ALLOW** — verified by tests and the `check` cards:

- `dd if=/dev/zero of=disk.img bs=1M count=100` — cloning *to* an image file
- `dd if=/dev/sda of=backup.img` — reading a disk *to* a file (the `of=` is the file)
- `dd of=/dev/null`, `dd if=/dev/urandom of=random.bin` — pseudo-devices
- `mkfs.ext4 disk.img` — filesystem in a loopback image
- `cat foo > /dev/null`, `make 2>/dev/null` — redirects to non-devices / stderr

## Changes

- `internal/analyzer/shell` — new `BlockDeviceWrite` fact; `isBlockDevice` classifier (device families under `/dev/`); output-redirect detection.
- `internal/policy` — `block_device_write` `ShellMatch` field + engine wiring.
- `internal/policy/builtin/recommended.yaml` — `destructive-disk-write` rule (deny).
- Table-driven tests at both the analyzer and engine levels (catches **and** false-positive guards).

`go build`, `go vet`, `gofmt`, and `go test ./...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBjdLzSDww859nrM7pQnjT