### PR TITLE
Replace fork-bomb regex with an AST detector

### DIFF
--- a/internal/analyzer/shell/shell.go
+++ b/internal/analyzer/shell/shell.go
@@ -116,6 +116,11 @@ type Analysis struct {
 	// shell or interpreter (curl ... | sh).
 	PipeToShellFromNet bool
 
+	// ForkBomb is true when a function definition pipes into itself on both
+	// sides (`:(){ :|:& };:` plus renamed, spaced, and `&`-less variants) — the
+	// self-replicating shape that exhausts the machine.
+	ForkBomb bool
+
 	// SecretRead is the highest-confidence secret reference seen in the command
 	// (e.g. a private key, cloud credential, or .env file being read).
 	SecretRead SecretConfidence
@@ -229,6 +234,10 @@ func Analyze(command, cwd string) Analysis {
 				if isNetToShellPipe(n) {
 					a.PipeToShellFromNet = true
 				}
+			}
+		case *syntax.FuncDecl:
+			if isForkBomb(n) {
+				a.ForkBomb = true
 			}
 		}
 		return true
@@ -636,6 +645,45 @@ func commandNameOfStmt(stmt *syntax.Stmt) string {
 		return name
 	}
 	return ""
+}
+
+// isForkBomb reports whether a function definition is a fork bomb: its body
+// contains a pipeline that calls the function's own name on both sides — the
+// canonical `:(){ :|:& };:` plus renamed, spaced, and `&`-less variants such as
+// `bomb(){ bomb|bomb& }` or `:(){ :|:; }`. Every invocation spawns two or more
+// of itself, so processes multiply exponentially and exhaust the machine.
+// Detecting the definition (rather than the trailing trigger call) also catches
+// define-now/run-later forms the old literal regex missed.
+//
+// The signature is the *self-pipe*: a pipeline with two or more stages that call
+// the function itself. The background `&` is incidental (it merely makes each
+// invocation return sooner), so it is not required. Requiring two self-calls is
+// what keeps false positives out — ordinary recursion (`f(){ f; }`) has no pipe,
+// and a tail-recursive stream (`f(){ cmd | f; }`) calls itself only once.
+func isForkBomb(fn *syntax.FuncDecl) bool {
+	if fn.Name == nil || fn.Body == nil {
+		return false
+	}
+	name := fn.Name.Value
+	found := false
+	syntax.Walk(fn.Body, func(node syntax.Node) bool {
+		bc, ok := node.(*syntax.BinaryCmd)
+		if !ok || (bc.Op != syntax.Pipe && bc.Op != syntax.PipeAll) {
+			return true
+		}
+		selfCalls := 0
+		for _, stage := range pipelineStages(&syntax.Stmt{Cmd: bc}) {
+			if stage == name {
+				selfCalls++
+			}
+		}
+		if selfCalls >= 2 {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
 }
 
 // classifySecret rates a single command word that may reference secret

--- a/internal/analyzer/shell/shell_test.go
+++ b/internal/analyzer/shell/shell_test.go
@@ -116,6 +116,44 @@ func TestPipeToShellFromNet(t *testing.T) {
 	}
 }
 
+func TestForkBomb(t *testing.T) {
+	cases := []struct {
+		name    string
+		command string
+		want    bool
+	}{
+		// Fork bombs — the self-pipe, in various disguises.
+		{"canonical", ":(){ :|:& };:", true},
+		{"spaced", ": () { : | : & }; :", true},
+		{"renamed", "bomb(){ bomb|bomb& };bomb", true},
+		{"renamed spaced", "boom() { boom | boom & }; boom", true},
+		{"no background", ":(){ :|:; };:", true},
+		{"definition only, no trigger", ":(){ :|:& }", true},
+		{"three stages", "x(){ x|x|x& };x", true},
+
+		// Not fork bombs (false-positive guards).
+		{"plain recursion", "f(){ f; }; f", false},
+		{"tail-recursive stream", "stream(){ cat input | stream; }", false},
+		{"backgrounded pipe, no self-call", "worker(){ producer | consumer & }", false},
+		{"single self-call", "run(){ setup | run & }; run", false},
+		{"function without a pipe", "deploy(){ build && test; }", false},
+		{"plain pipe, no function", "echo hi | grep h", false},
+		{"ordinary command", "ls -la", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := Analyze(tc.command, "/work")
+			if !a.Parsed {
+				t.Fatalf("command did not parse: %q", tc.command)
+			}
+			if a.ForkBomb != tc.want {
+				t.Errorf("ForkBomb = %v, want %v", a.ForkBomb, tc.want)
+			}
+		})
+	}
+}
+
 func TestChmodFacts(t *testing.T) {
 	const cwd = "/Users/dev/project"
 	cases := []struct {

--- a/internal/policy/builtin/recommended.yaml
+++ b/internal/policy/builtin/recommended.yaml
@@ -147,7 +147,8 @@ rules:
     effect: deny
     message: Leash blocked what looks like a fork bomb.
     match:
-      regex: ':\s*\(\s*\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:'
+      shell:
+        fork_bomb: true
 
   - id: read-credential-files
     description: Reading private keys or cloud credentials (their contents enter the agent's context)

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -159,6 +159,9 @@ func matchShell(m *ShellMatch, a *shell.Analysis) bool {
 	if m.PipeToShell && !a.PipeToShellFromNet {
 		return false
 	}
+	if m.ForkBomb && !a.ForkBomb {
+		return false
+	}
 	if m.SecretExfil != "" {
 		// Exfiltration = a secret is read AND data leaves over the network.
 		if !a.NetEgress || a.SecretRead == shell.SecretNone {

--- a/internal/policy/engine_test.go
+++ b/internal/policy/engine_test.go
@@ -58,6 +58,40 @@ func TestRecommendedShellDecisions(t *testing.T) {
 	}
 }
 
+func TestRecommendedForkBombDecisions(t *testing.T) {
+	e := recommendedEngine(t)
+
+	cases := []struct {
+		command string
+		want    Effect
+		rule    string
+	}{
+		// Fork bombs -> deny (now via the AST fact, not the old regex).
+		{":(){ :|:& };:", EffectDeny, "fork-bomb"},
+		{"bomb(){ bomb|bomb& };bomb", EffectDeny, "fork-bomb"},
+		{":(){ :|:; };:", EffectDeny, "fork-bomb"},
+		// Legit recursion / streaming must stay allowed.
+		{"f(){ f; }; f", EffectAllow, ""},
+		{"stream(){ cat input | stream; }", EffectAllow, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.command, func(t *testing.T) {
+			d := e.Evaluate(Action{Kind: ActionShell, Command: tc.command, Cwd: "/work"})
+			if d.Effect != tc.want {
+				t.Fatalf("Effect = %q, want %q", d.Effect, tc.want)
+			}
+			gotRule := ""
+			if d.Rule != nil {
+				gotRule = d.Rule.ID
+			}
+			if gotRule != tc.rule {
+				t.Errorf("deciding rule = %q, want %q", gotRule, tc.rule)
+			}
+		})
+	}
+}
+
 func TestRecommendedFileDecisions(t *testing.T) {
 	e := recommendedEngine(t)
 	home, _ := os.UserHomeDir()

--- a/internal/policy/rule.go
+++ b/internal/policy/rule.go
@@ -52,6 +52,7 @@ type ShellMatch struct {
 	ForcePush          bool     `yaml:"force_push,omitempty"`
 	HistoryRewrite     bool     `yaml:"history_rewrite,omitempty"`
 	PipeToShell        bool     `yaml:"pipe_to_shell,omitempty"`
+	ForkBomb           bool     `yaml:"fork_bomb,omitempty"`
 	SecretExfil        string   `yaml:"secret_exfil,omitempty"` // high|any
 	SecretRead         string   `yaml:"secret_read,omitempty"`  // high|any — a reader command dumps a secret to stdout
 	CommandIn          []string `yaml:"command_in,omitempty"`


### PR DESCRIPTION
Closes ATR-13. Promotes the fork-bomb rule from the literal regex fallback to a semantic AST detector.

## Why

The `recommended` pack matched only `:(){ :|:& };:` via a literal regex, so **renamed, re-spaced, and `&`-less variants slipped through** — trivial to evade.

## What

- New `ForkBomb` analyzer fact + `fork_bomb` `ShellMatch` predicate.
- `isForkBomb` flags a `FuncDecl` whose body contains a **pipeline that calls the function's own name on ≥2 sides** — the self-replicating shape. It reuses the existing `pipelineStages` helper from the curl-pipe detector.
- Detecting the **definition** (not the trailing trigger call) also catches define-now / run-later forms.
- The `fork-bomb` rule keeps its id / `deny` / message and now matches the fact; the regex is removed.

## Deliberate strengthening beyond the issue's literal scope

The issue scoped to the backgrounded (`&`) form, but the exponential engine is the **self-pipe** itself. `:(){ :|:; };:` **without** `&` is an equally lethal bomb and an obvious evasion of a background-gated check, so I do **not** require `&`. The "≥2 self-calls" invariant is what keeps false positives at zero, so this is strictly-more-catch at no FP cost.

## Verified (via `leash check`, analyzing not executing)

| Command | Decision | Note |
|---|---|---|
| `:(){ :|:& };:` | **deny** | canonical |
| `bomb(){ bomb\|bomb& };bomb` | **deny** | renamed — old regex missed |
| `:(){ :|:; };:` | **deny** | `&`-less — old regex missed |
| `f(){ f; }; f` | allow | ordinary recursion (no pipe) |
| `stream(){ cat input \| stream; }` | allow | tail-recursive stream (1 self-call) |
| `run(){ setup \| run & }; run` | allow | single self-call |

Table-driven tests cover all of the above (analyzer + engine levels). `gofmt`, `go build`, `go vet`, `go test ./...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBjdLzSDww859nrM7pQnjT