### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+# Cancel superseded runs on the same branch / PR.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Check formatting (gofmt -s)
+        run: |
+          unformatted="$(gofmt -s -l .)"
+          if [ -n "$unformatted" ]; then
+            echo "These files are not formatted — run 'make fmt':"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test ./...


### PR DESCRIPTION
Closes ATR-25. Adds continuous integration so tests run automatically on every PR.

## What

`.github/workflows/ci.yml` — a single `ubuntu-latest` job that runs the same gate as local development:

- **Go pinned from `go.mod`** via `actions/setup-go` (`go-version-file`), with module caching.
- `gofmt -s -l` format check (parity with `make fmt`, which uses `-s`)
- `go vet ./...`
- `go build ./...` (all packages)
- `go test ./...`

**Triggers:** `pull_request` (all) + `push` to `main`. `concurrency` cancels superseded runs on the same ref; a 10-minute timeout guards against hangs.

## Verification

The exact gate was dry-run locally on current `main` — `gofmt -s` clean, vet/build/test all green. This PR itself exercises the workflow, so its own CI check validates it end-to-end.

## Follow-up (not in scope)

Make the `test` check **required** to merge via branch protection (a repo setting — needs admin, can't be set from a workflow file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBjdLzSDww859nrM7pQnjT