### PR TITLE
Add npx installer (esbuild-pattern npm packages)

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,0 +1,53 @@
+name: npm
+
+on:
+  push:
+    tags: ["v*"]
+  # Validate the assembler on PRs that touch it, without publishing.
+  pull_request:
+    paths:
+      - "npm/**"
+      - ".github/workflows/npm.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  npm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Resolve version
+        id: ver
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=0.0.0-ci" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Assemble packages
+        run: node npm/build.mjs "${{ steps.ver.outputs.version }}"
+
+      # Publish platform packages first, then the main package that depends on them.
+      - name: Publish
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          for dir in npm/build/@hoophq/* npm/build/leash; do
+            npm publish "$dir" --access public
+          done
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build output
 /leash
 /dist/
+/npm/build/
 *.test
 *.out
 

--- a/README.md
+++ b/README.md
@@ -51,13 +51,21 @@ differently:
 
 ## Install
 
-### Homebrew (macOS / Linux)
+### Homebrew (macOS)
 
 ```bash
 brew install hoophq/tap/leash
 ```
 
-> Lands with the first tagged release. Until then, install from source:
+### npx (macOS / Linux · x64 / arm64)
+
+```bash
+npx @hoophq/leash check 'rm -rf ~'
+npx @hoophq/leash init            # wire it into Claude Code
+```
+
+> Both install a real native binary and land with the first tagged release.
+> Until then, install from source:
 
 ### From source
 
@@ -71,8 +79,6 @@ or clone and build:
 git clone https://github.com/hoophq/leash && cd leash
 make build      # -> ./dist/leash
 ```
-
-> An `npx leash` one-liner is next on the installer roadmap.
 
 ---
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,21 @@
+# @hoophq/leash
+
+**Guardrails for AI coding agents.** Leash inspects every command your agent
+tries to run and stops the catastrophic ones — recursive deletes of your home
+directory, secret exfiltration, `curl | sh`, force-pushes — *before* they
+execute.
+
+```bash
+npx @hoophq/leash check 'rm -rf ~'      # DENY
+npx @hoophq/leash init                  # wire it into Claude Code
+```
+
+This package ships the native `leash` binary. It uses the esbuild/biome
+distribution model: the correct `@hoophq/leash-<os>-<cpu>` build is pulled in as
+an optional dependency via npm's `os`/`cpu` selection — **no postinstall script
+and no download at runtime** (a tool that flags those shouldn't ship as one).
+
+Supported platforms: macOS and Linux on x64/arm64. For anything else, install
+from source: `go install github.com/hoophq/leash/cmd/leash@latest`.
+
+Full docs: https://github.com/hoophq/leash

--- a/npm/bin/leash.js
+++ b/npm/bin/leash.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+"use strict";
+
+// Resolve the prebuilt leash binary for this platform and exec it.
+//
+// The matching @hoophq/leash-<os>-<cpu> package is installed by npm as an
+// optionalDependency, gated by its own `os`/`cpu` fields — so exactly one lands
+// on any given machine. There is no postinstall and no download at runtime: a
+// guardrail that flags `curl | sh` and postinstall hooks must not ship as one.
+
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+
+function binaryPath() {
+  const pkg = `@hoophq/leash-${process.platform}-${process.arch}`;
+  try {
+    return require.resolve(`${pkg}/bin/leash`);
+  } catch {
+    return null;
+  }
+}
+
+const bin = binaryPath();
+if (!bin) {
+  console.error(
+    `leash: no prebuilt binary for ${process.platform}-${process.arch}.\n` +
+      `Supported: darwin/linux on x64/arm64.\n` +
+      `Install from source instead: go install github.com/hoophq/leash/cmd/leash@latest`
+  );
+  process.exit(1);
+}
+
+// Be defensive about the executable bit surviving packaging/extraction.
+try {
+  fs.chmodSync(bin, 0o755);
+} catch {
+  // read-only store, etc. — spawn will surface any real problem
+}
+
+const res = spawnSync(bin, process.argv.slice(2), { stdio: "inherit" });
+if (res.error) {
+  console.error(`leash: ${res.error.message}`);
+  process.exit(1);
+}
+process.exit(res.status === null ? 1 : res.status);

--- a/npm/build.mjs
+++ b/npm/build.mjs
@@ -1,0 +1,96 @@
+// Assemble the npm packages for a release: the main @hoophq/leash package plus
+// one @hoophq/leash-<os>-<cpu> package per platform, each carrying a natively
+// cross-compiled binary. The main package selects the right one at install time
+// via optionalDependencies + os/cpu (the esbuild/biome pattern — no postinstall,
+// no runtime download). leash is pure Go, so cross-compilation is just `go build`
+// with GOOS/GOARCH.
+//
+//   node npm/build.mjs <version>     # -> npm/build/{leash, @hoophq/leash-*}
+//
+// The release workflow runs this then `npm publish`es each package directory.
+
+import { execFileSync } from "node:child_process";
+import { cpSync, mkdirSync, rmSync, writeFileSync, chmodSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const version = process.argv[2];
+if (!version) {
+  console.error("usage: node npm/build.mjs <version>");
+  process.exit(1);
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, "..");
+const outDir = join(here, "build");
+const scope = "@hoophq";
+
+// GOOS/GOARCH -> npm os/cpu (Node's naming, which the shim matches at runtime).
+const targets = [
+  { goos: "darwin", goarch: "amd64", os: "darwin", cpu: "x64" },
+  { goos: "darwin", goarch: "arm64", os: "darwin", cpu: "arm64" },
+  { goos: "linux", goarch: "amd64", os: "linux", cpu: "x64" },
+  { goos: "linux", goarch: "arm64", os: "linux", cpu: "arm64" },
+];
+
+rmSync(outDir, { recursive: true, force: true });
+
+const optionalDependencies = {};
+for (const t of targets) {
+  const name = `${scope}/leash-${t.os}-${t.cpu}`;
+  const pkgDir = join(outDir, name);
+  const binPath = join(pkgDir, "bin", "leash");
+  mkdirSync(dirname(binPath), { recursive: true });
+
+  execFileSync(
+    "go",
+    ["build", "-trimpath", "-ldflags", `-s -w -X main.version=${version}`, "-o", binPath, "./cmd/leash"],
+    { cwd: repoRoot, stdio: "inherit", env: { ...process.env, GOOS: t.goos, GOARCH: t.goarch, CGO_ENABLED: "0" } }
+  );
+  chmodSync(binPath, 0o755);
+
+  writeFileSync(
+    join(pkgDir, "package.json"),
+    JSON.stringify(
+      {
+        name,
+        version,
+        description: `Prebuilt leash binary for ${t.os}-${t.cpu}`,
+        repository: "github:hoophq/leash",
+        license: "MIT",
+        os: [t.os],
+        cpu: [t.cpu],
+        files: ["bin"],
+      },
+      null,
+      2
+    ) + "\n"
+  );
+  optionalDependencies[name] = version;
+  console.log(`built ${name}`);
+}
+
+// Main package: the bin shim + a manifest that pulls in exactly one platform pkg.
+const mainDir = join(outDir, "leash");
+mkdirSync(join(mainDir, "bin"), { recursive: true });
+cpSync(join(here, "bin", "leash.js"), join(mainDir, "bin", "leash.js"));
+cpSync(join(here, "README.md"), join(mainDir, "README.md"));
+writeFileSync(
+  join(mainDir, "package.json"),
+  JSON.stringify(
+    {
+      name: `${scope}/leash`,
+      version,
+      description: "Guardrails for AI coding agents — blocks catastrophic tool calls before they run",
+      repository: "github:hoophq/leash",
+      homepage: "https://github.com/hoophq/leash",
+      license: "MIT",
+      bin: { leash: "bin/leash.js" },
+      optionalDependencies,
+      files: ["bin"],
+    },
+    null,
+    2
+  ) + "\n"
+);
+console.log(`assembled ${scope}/leash`);


### PR DESCRIPTION
Finishes **ATR-8** — the second installer, `npx @hoophq/leash`.

## The principled pattern

Uses the **esbuild/biome** distribution model, not a postinstall download. The main `@hoophq/leash` package declares the four `@hoophq/leash-<os>-<cpu>` builds as `optionalDependencies`, each gated by its own `os`/`cpu` — so npm installs **exactly the matching one**. **No `postinstall`, no runtime download.** A guardrail that flags `curl | sh` and postinstall hooks shouldn't ship as one.

- **`npm/bin/leash.js`** — shim: `require.resolve`s the platform package's binary, `chmod +x` (defensive), and execs it with args forwarded.
- **`npm/build.mjs`** — cross-builds the four binaries (`go build` with `GOOS`/`GOARCH`; leash is pure Go) and assembles the main + platform packages for a given version.
- **`.github/workflows/npm.yml`** — `v*` tag → assemble + `npm publish` all packages (needs `NPM_TOKEN`); PRs touching `npm/**` → **assemble-only**, so the script + cross-compile are CI-validated (see this PR's `npm` check).
- **README** — install now offers Homebrew (macOS) + npx (macOS/Linux, x64/arm64).

## Validated locally (end-to-end)

```
$ node npm/build.mjs 9.9.9-test        # cross-builds 4 targets, assembles packages
$ node .../leash/bin/leash.js version  # via the shim → the real binary
9.9.9-test
$ node .../leash/bin/leash.js check 'rm -rf ~'
  DENY   rm -rf ~
```

The shim resolves the current-platform package, execs the binary, forwards args, and the ldflags-injected version comes through.

## Activation (post-launch)

Create the `@hoophq` npm scope and add the `NPM_TOKEN` secret, then push a `v*` tag — the workflow publishes all five packages. (Homebrew's activation steps are in #11 / ATR-27.)

`go test`, `gofmt -s`, `go vet` unaffected (no Go source changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBjdLzSDww859nrM7pQnjT