### PR TITLE
Strip quarantine in the cask postflight — Gatekeeper kills the unsigned binary

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -48,8 +48,8 @@ changelog:
 
 # Publish a Homebrew Cask to hoophq/homebrew-tap so macOS users can
 # `brew install hoophq/tap/leash`. Casks (not formulae) are GoReleaser's
-# supported path for pre-built binaries and they clear the Gatekeeper quarantine
-# on the unsigned binary; Linux users get the tarball, `go install`, or npx.
+# supported path for pre-built binaries; Linux users get the tarball, `go
+# install`, or npx.
 # Requires HOMEBREW_TAP_GITHUB_TOKEN (a PAT with write access to the tap) at
 # release time.
 homebrew_casks:
@@ -60,3 +60,13 @@ homebrew_casks:
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     homepage: "https://github.com/hoophq/leash"
     description: "Guardrails for AI coding agents — blocks catastrophic tool calls before they run"
+    # Homebrew quarantines cask downloads, and Gatekeeper SIGKILLs the ad-hoc
+    # (linker-signed) Go binary on first run — install succeeds, running dies.
+    # Strip the quarantine bit post-install (GoReleaser's documented pattern)
+    # until the binary is properly signed + notarized.
+    hooks:
+      post:
+        install: |
+          if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/leash"]
+          end


### PR DESCRIPTION
Found while verifying the v0.0.1 launch end-to-end: `brew install hoophq/tap/leash` succeeded, but **running** `leash` died instantly with SIGKILL. Homebrew quarantines cask downloads, and Gatekeeper refuses the ad-hoc (linker-signed, not notarized) Go binary on first run — the opposite of what the release-pipeline PR (#11) assumed casks did.

## The fix

GoReleaser's documented pattern for unsigned cask binaries: a post-install hook that strips `com.apple.quarantine` from the staged binary. Also corrects the config comment that claimed casks clear quarantine by themselves.

## Verified

- `goreleaser check` — config valid
- `goreleaser release --snapshot` — the rendered cask's `postflight` block is byte-identical to the hot-patch already pushed to `hoophq/homebrew-tap` for v0.0.1
- On the live v0.0.1 cask (hot-patched): `brew reinstall --cask hoophq/tap/leash` → quarantine xattr gone → `leash version` prints `0.0.1`, `leash check 'rm -rf ~'` prints the DENY card

Longer-term the right fix is signing + notarization; this unblocks macOS users today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019p7PaohYrio1E61CSbtCm4