### PR TITLE
docs: restore the npx install path — npm goes live with v0.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,10 @@ where it came from.
 brew install hoophq/tap/leash
 ```
 
-> Both land with the first tagged release.
+```bash
+# npx — macOS / Linux, no install
+npx @hoophq/leash
+```
 
 ## Quickstart — Claude Code
 


### PR DESCRIPTION
Restores the npx install lines removed in f3b192f (npm publish was deferred at launch; `NPM_TOKEN` is now set, so `@hoophq/leash` ships with the v0.0.2 tag). Also drops the stale "Both land with the first tagged release" note and splits the install commands into separate code blocks so each copies cleanly on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JTWrE3KbTBQDsrw79V3qsP