### PR TITLE
Write an upgrade-stable path into the Claude Code hook, and heal stale ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ brew install hoophq/tap/leash
 ```
 
 ```bash
-# npx — macOS / Linux, no install
-npx @hoophq/leash
+# npm — macOS / Linux
+npm install -g @hoophq/leash
 ```
 
 ## Quickstart — Claude Code
@@ -194,7 +194,7 @@ developer can't override it.
 
 - [x] Semantic detectors — deletes, disk wipes, fork bombs, exfiltration,
       world-writable, off-registry installs, manifest hooks, persistence
-- [x] One-line installers — Homebrew, npx
+- [x] One-line installers — Homebrew, npm
 - [ ] More agents — Codex, Cursor, Gemini CLI
 - [ ] A shareable rulepack registry — `leash add <pack>`
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -31,18 +31,18 @@ func newInitCommand() *cobra.Command {
 			if err != nil {
 				return fail(cmd, err)
 			}
-			binary, err := hookInvocation()
+			result, err := installHook(path, hookInvocation())
 			if err != nil {
 				return fail(cmd, err)
 			}
-			changed, err := installHook(path, binary)
-			if err != nil {
-				return fail(cmd, err)
-			}
-			if changed {
+			switch result {
+			case hookInstalled:
 				fmt.Fprintf(cmd.OutOrStdout(), "Installed Leash hook in %s\n", path)
 				fmt.Fprintf(cmd.OutOrStdout(), "Restart Claude Code (or start a new session) to activate it.\n")
-			} else {
+			case hookUpdated:
+				fmt.Fprintf(cmd.OutOrStdout(), "Updated the Leash hook command in %s\n", path)
+				fmt.Fprintf(cmd.OutOrStdout(), "Restart Claude Code (or start a new session) to pick it up.\n")
+			default:
 				fmt.Fprintf(cmd.OutOrStdout(), "Leash hook already present in %s\n", path)
 			}
 			return nil
@@ -69,38 +69,63 @@ func settingsPath(global bool) (string, error) {
 }
 
 // hookInvocation returns the command string Claude Code should run. It uses the
-// absolute path of the current binary so the hook works regardless of PATH.
-func hookInvocation() (string, error) {
+// absolute path of the current binary so the hook works regardless of PATH, but
+// keeps symlinks unresolved: package managers point a stable symlink (e.g.
+// /opt/homebrew/bin/leash) at a version-pinned target that vanishes on upgrade,
+// so resolving it would break the hook at the next `brew upgrade`.
+func hookInvocation() string {
 	exe, err := os.Executable()
 	if err != nil {
-		return hookCommand, nil // fall back to PATH lookup of "leash"
+		return hookCommand // fall back to PATH lookup of "leash"
 	}
-	resolved, err := filepath.EvalSymlinks(exe)
-	if err != nil {
-		resolved = exe
-	}
-	return fmt.Sprintf("%s hook claude-code", resolved), nil
+	return fmt.Sprintf("%s hook claude-code", exe)
 }
 
+// hookInstallResult describes what installHook changed.
+type hookInstallResult int
+
+const (
+	hookUnchanged hookInstallResult = iota
+	hookInstalled
+	hookUpdated
+)
+
 // installHook merges a PreToolUse hook into the settings file at path, creating
-// it if necessary. It returns whether a change was made.
-func installHook(path, command string) (bool, error) {
+// it if necessary. An existing leash hook whose command differs — e.g. a stale
+// binary path left by a previous install — is updated in place, so re-running
+// `leash init` always converges on a working hook.
+func installHook(path, command string) (hookInstallResult, error) {
 	settings := map[string]any{}
 	if data, err := os.ReadFile(path); err == nil {
 		if len(data) > 0 {
 			if err := json.Unmarshal(data, &settings); err != nil {
-				return false, fmt.Errorf("%s is not valid JSON: %w", path, err)
+				return hookUnchanged, fmt.Errorf("%s is not valid JSON: %w", path, err)
 			}
 		}
 	} else if !os.IsNotExist(err) {
-		return false, err
+		return hookUnchanged, err
 	}
 
 	hooks := asMap(settings["hooks"])
 	preToolUse := asSlice(hooks["PreToolUse"])
 
-	if hookPresent(preToolUse) {
-		return false, nil
+	result := hookUnchanged
+	for _, e := range preToolUse {
+		for _, h := range asSlice(asMap(e)["hooks"]) {
+			hm := asMap(h)
+			cmd, ok := hm["command"].(string)
+			if !ok || !containsHook(cmd) {
+				continue
+			}
+			if cmd != command {
+				hm["command"] = command
+				return writeSettings(path, settings, hooks, preToolUse, hookUpdated)
+			}
+			result = hookInstalled // present and current
+		}
+	}
+	if result == hookInstalled {
+		return hookUnchanged, nil
 	}
 
 	entry := map[string]any{
@@ -110,35 +135,25 @@ func installHook(path, command string) (bool, error) {
 		},
 	}
 	preToolUse = append(preToolUse, entry)
+	return writeSettings(path, settings, hooks, preToolUse, hookInstalled)
+}
+
+func writeSettings(path string, settings, hooks map[string]any, preToolUse []any, result hookInstallResult) (hookInstallResult, error) {
 	hooks["PreToolUse"] = preToolUse
 	settings["hooks"] = hooks
 
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return false, err
+		return hookUnchanged, err
 	}
 	out, err := json.MarshalIndent(settings, "", "  ")
 	if err != nil {
-		return false, err
+		return hookUnchanged, err
 	}
 	out = append(out, '\n')
 	if err := os.WriteFile(path, out, 0o644); err != nil {
-		return false, err
+		return hookUnchanged, err
 	}
-	return true, nil
-}
-
-// hookPresent reports whether any PreToolUse entry already runs a leash hook.
-func hookPresent(entries []any) bool {
-	for _, e := range entries {
-		em := asMap(e)
-		for _, h := range asSlice(em["hooks"]) {
-			hm := asMap(h)
-			if cmd, ok := hm["command"].(string); ok && containsHook(cmd) {
-				return true
-			}
-		}
-	}
-	return false
+	return result, nil
 }
 
 func containsHook(cmd string) bool {

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -1,0 +1,204 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const wantCommand = "/opt/homebrew/bin/leash hook claude-code"
+
+// hookCommands walks hooks.PreToolUse and returns every hook command string.
+func hookCommands(t *testing.T, path string) []string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("settings not valid JSON: %v", err)
+	}
+	var cmds []string
+	for _, e := range asSlice(asMap(settings["hooks"])["PreToolUse"]) {
+		for _, h := range asSlice(asMap(e)["hooks"]) {
+			if cmd, ok := asMap(h)["command"].(string); ok {
+				cmds = append(cmds, cmd)
+			}
+		}
+	}
+	return cmds
+}
+
+func TestInstallHook(t *testing.T) {
+	tests := []struct {
+		name    string
+		initial string // "" means the settings file does not exist yet
+		want    hookInstallResult
+		cmds    []string // expected hook commands after the call, in order
+	}{
+		{
+			name: "creates settings file and parent dirs",
+			want: hookInstalled,
+			cmds: []string{wantCommand},
+		},
+		{
+			name: "appends alongside unrelated hooks",
+			initial: `{"permissions":{"allow":["Bash(ls *)"]},
+				"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"echo hi"}]}]}}`,
+			want: hookInstalled,
+			cmds: []string{"echo hi", wantCommand},
+		},
+		{
+			name: "idempotent when the command already matches",
+			initial: `{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[
+				{"type":"command","command":"/opt/homebrew/bin/leash hook claude-code"}]}]}}`,
+			want: hookUnchanged,
+			cmds: []string{wantCommand},
+		},
+		{
+			// The brew-cask trap: a previous init resolved the symlink into a
+			// version-pinned Caskroom path that no longer exists after upgrade.
+			// Re-running init must heal it, not report "already present".
+			name: "heals a stale binary path",
+			initial: `{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[
+				{"type":"command","command":"/opt/homebrew/Caskroom/leash/0.0.2/leash hook claude-code"}]}]}}`,
+			want: hookUpdated,
+			cmds: []string{wantCommand},
+		},
+		{
+			name:    "bare PATH command is recognized and healed to absolute",
+			initial: `{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"leash hook claude-code"}]}]}}`,
+			want:    hookUpdated,
+			cmds:    []string{wantCommand},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), ".claude", "settings.json")
+			if tt.initial != "" {
+				if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(path, []byte(tt.initial), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			got, err := installHook(path, wantCommand)
+			if err != nil {
+				t.Fatalf("installHook: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("result = %v, want %v", got, tt.want)
+			}
+
+			cmds := hookCommands(t, path)
+			if len(cmds) != len(tt.cmds) {
+				t.Fatalf("hook commands = %q, want %q", cmds, tt.cmds)
+			}
+			for i := range cmds {
+				if cmds[i] != tt.cmds[i] {
+					t.Fatalf("hook command[%d] = %q, want %q", i, cmds[i], tt.cmds[i])
+				}
+			}
+		})
+	}
+}
+
+func TestInstallHookPreservesUnrelatedSettings(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	initial := `{"permissions":{"allow":["Bash(ls *)"]},"model":"opus"}`
+	if err := os.WriteFile(path, []byte(initial), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := installHook(path, wantCommand); err != nil {
+		t.Fatalf("installHook: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatal(err)
+	}
+	if settings["model"] != "opus" {
+		t.Errorf("model = %v, want opus", settings["model"])
+	}
+	allow := asSlice(asMap(settings["permissions"])["allow"])
+	if len(allow) != 1 || allow[0] != "Bash(ls *)" {
+		t.Errorf("permissions.allow = %v, want [Bash(ls *)]", allow)
+	}
+}
+
+func TestInstallHookUnchangedDoesNotRewrite(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	// Deliberately not in MarshalIndent formatting: a rewrite would reformat.
+	initial := `{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"` + wantCommand + `"}]}]}}`
+	if err := os.WriteFile(path, []byte(initial), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, err := installHook(path, wantCommand); err != nil || got != hookUnchanged {
+		t.Fatalf("installHook = %v, %v; want hookUnchanged, nil", got, err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != initial {
+		t.Errorf("file was rewritten despite no change:\n%s", data)
+	}
+}
+
+func TestInstallHookRejectsInvalidJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installHook(path, wantCommand); err == nil {
+		t.Fatal("expected an error for invalid JSON, got nil")
+	}
+}
+
+func TestHookInvocationKeepsSymlinksUnresolved(t *testing.T) {
+	got := hookInvocation()
+	if !strings.HasSuffix(got, " hook claude-code") {
+		t.Fatalf("hookInvocation() = %q, want suffix %q", got, " hook claude-code")
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		t.Skipf("os.Executable: %v", err)
+	}
+	// The invocation must use the executable path as-is — resolving symlinks is
+	// what pinned brew users to a Caskroom path that dies on upgrade.
+	if want := exe + " hook claude-code"; got != want {
+		t.Errorf("hookInvocation() = %q, want %q", got, want)
+	}
+}
+
+func TestContainsHook(t *testing.T) {
+	tests := []struct {
+		cmd  string
+		want bool
+	}{
+		{"leash hook claude-code", true},
+		{"/opt/homebrew/bin/leash hook claude-code", true},
+		{"/Users/dev/go/bin/leash hook claude-code", true},
+		{"leash check 'rm -rf ~'", false},
+		{"echo leash hook claude-code | wc -l", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := containsHook(tt.cmd); got != tt.want {
+			t.Errorf("containsHook(%q) = %v, want %v", tt.cmd, got, tt.want)
+		}
+	}
+}

--- a/npm/README.md
+++ b/npm/README.md
@@ -6,8 +6,10 @@ directory, secret exfiltration, `curl | sh`, force-pushes — *before* they
 execute.
 
 ```bash
-npx @hoophq/leash check 'rm -rf ~'      # DENY
-npx @hoophq/leash init                  # wire it into Claude Code
+npm install -g @hoophq/leash
+
+leash check 'rm -rf ~'      # DENY
+leash init                  # wire it into Claude Code
 ```
 
 This package ships the native `leash` binary. It uses the esbuild/biome


### PR DESCRIPTION
Fixes the brew-cask trap found while verifying v0.0.2:

- **`leash init` resolved symlinks** when recording the hook command, so brew users got the version-pinned `/opt/homebrew/Caskroom/leash/<version>/leash` written into their settings — and the next `brew upgrade leash` purged that directory, silently disarming leash (hook fails open) until re-init. `hookInvocation` now keeps `os.Executable()` unresolved, so the stable `/opt/homebrew/bin/leash` symlink is recorded instead.
- **`installHook` skipped when any leash hook was present**, so re-running `leash init` couldn't repair a dead path. It now updates an existing leash hook whose command differs (`Updated the Leash hook command in …`), making init convergent.
- First tests for `internal/cli`: install/idempotence/healing table, unrelated-settings preservation, no-rewrite-when-unchanged, invalid JSON, and a symlink-nonresolution pin (which fails under the old code on macOS, where the test binary runs under the `/var → /private/var` symlink).
- docs: the install section now installs — `npm install -g @hoophq/leash` instead of one-shot `npx`, in both READMEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JTWrE3KbTBQDsrw79V3qsP