### PR TITLE
Shareable rulepack registry: leash add/search/update/remove + extends composition

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,13 @@ central audit, and approval workflows out of scope.
   net→shell pipe). **This is the differentiator** — see Conventions.
 - `internal/adapter/<agent>/` — translate one agent's tool call ⇄ neutral `Action`.
   `claudecode` (Claude Code PreToolUse) is the first adapter.
-- `internal/cli/` — Cobra commands: `check`, `hook`, `init`, `version`.
+- `internal/store/` — the user-level state dir (`~/.leash`): packs installed via
+  `leash add` (the packs dir is the source of truth) + `packs.lock.json` metadata.
+- `internal/registry/` — fetch + sha256-verify packs from a static index
+  (`registry/` in this repo, read raw off main). Only the explicit commands
+  import it — **nothing on the eval path may ever touch the network**.
+- `internal/cli/` — Cobra commands: `check`, `hook`, `init`, `add`, `search`,
+  `update`, `remove`, `version`.
 - `cmd/leash/` — entrypoint; `version` is injected via `-ldflags "-X main.version=..."`.
 
 ## Conventions (load-bearing)
@@ -52,10 +58,17 @@ central audit, and approval workflows out of scope.
 
 ## Rulepacks
 
-- The embedded `recommended` pack is always active. Users layer their own rules
-  via `./.leash.yaml` (auto-discovered) or `--rules <file>`.
+- Layering order: the embedded `recommended` pack (always active), then packs
+  installed with `leash add` (`~/.leash/packs`, a-z), then `./.leash.yaml`
+  (auto-discovered), then `--rules <file>`. Any pack can pull others in below
+  itself with `extends:` (installed name or relative path; resolved in
+  `internal/policy/resolve.go`, never over the network).
 - When several rules match, the most severe effect wins (`deny` > `ask` > `warn`
   > `allow`). Default when nothing matches is `allow`.
+- Ambient sources (installed packs, `.leash.yaml`) degrade on error — warn and
+  skip, the rest keep protecting; an explicit `--rules` failure stays loud.
+- Seed packs live in `registry/packs/` + `registry/index.yaml`; after editing a
+  pack, recompute its `sha256` in the index (the seed test enforces this).
 
 ## Gotchas
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ claude
 ```
 
 **→ [All CLI commands](docs/cli.md)** — `init`, `check` (test a verdict without
-an agent), `hook`, and `version`.
+an agent), `add`/`search` (rulepacks), `hook`, and `version`.
 
 ---
 
@@ -161,6 +161,23 @@ overrides:
 
 ---
 
+## Grab a rulepack
+
+Guardrails others already wrote — Terraform, Kubernetes, production databases —
+install with one command and are active on the next tool call, in every project:
+
+```bash
+leash search                    # see what's published
+leash add terraform-safety      # checksum-verified, then live everywhere
+```
+
+Compose them in a committed `.leash.yaml` (`extends: [terraform-safety]`) to
+pin a baseline for your whole team — and publishing your own pack is just a PR.
+
+**→ [The registry: install, author, publish](docs/registry.md)**
+
+---
+
 ## How it works
 
 ```
@@ -195,9 +212,10 @@ developer can't override it.
 - [x] Semantic detectors — deletes, disk wipes, fork bombs, exfiltration,
       world-writable, off-registry installs, manifest hooks, persistence
 - [x] One-line installers — Homebrew, npm
+- [x] A shareable rulepack registry — `leash search` · `leash add <pack>` ·
+      [publish your own](docs/registry.md)
 - [ ] More agents — Codex, Cursor, Gemini CLI
-- [ ] A shareable rulepack registry — `leash add <pack>`
 
 ## License
 
-MIT © [hoop.dev](https://hoop.dev) — built by the team behind hoop.
+MIT © [hoop.dev](https://hoop.dev/?utm_source=leash&utm_medium=github&utm_campaign=att-launch-072026) — built by the team behind hoop.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,16 +49,18 @@ protocol (e.g. Claude Code's `permissionDecision`), never through exit codes.
 
 | Path | Responsibility |
 |---|---|
-| `internal/policy` | the engine (`Evaluate`, deny-overrides), the neutral `Action`/`Effect`/`Decision` types, `Rule`/`Match`/`Rulepack`, and the embedded `recommended` pack |
+| `internal/policy` | the engine (`Evaluate`, deny-overrides), the neutral `Action`/`Effect`/`Decision` types, `Rule`/`Match`/`Rulepack`, `extends:` resolution, and the embedded `recommended` pack |
 | `internal/analyzer/shell` | shell-AST analysis → semantic facts (the differentiator) |
 | `internal/analyzer/manifest` | content analysis of `package.json` / `setup.py` for install hooks |
 | `internal/adapter/<agent>` | translate one agent's tool call ⇄ neutral `Action` |
-| `internal/cli` | the `check`, `hook`, `init`, `version` commands |
+| `internal/store` | the user-level state dir (`~/.leash`): installed packs + lockfile |
+| `internal/registry` | fetch + checksum-verify packs from a static index (never on the eval path) |
+| `internal/cli` | the `check`, `hook`, `init`, `add`, `search`, `update`, `remove`, `version` commands |
 | `cmd/leash` | entrypoint |
 
 ## Extending Leash
 
-Two clean extension points:
+Three clean extension points:
 
 - **A new agent** = a new adapter under `internal/adapter/`. Map the agent's
   tool call to an `Action` and its decision format back out; the engine and
@@ -67,5 +69,9 @@ Two clean extension points:
   predicate in `policy`, then a rule that uses it. Every detector ships with a
   table-driven test that pins **both** the catch and the safe cases — the
   false-positive discipline is the product.
+- **A new rulepack** = a YAML file anyone can publish to the
+  [registry](registry.md) and anyone can install with `leash add` — no Go
+  involved. Because packs are agent-neutral, one published pack guards every
+  agent Leash supports.
 
 See [Rules](rules.md) for the match conditions those facts expose.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,9 +1,10 @@
 # CLI commands
 
-`leash` is a single binary with a handful of subcommands. The global
-`--rules <file>` flag layers an extra [rulepack](rules.md) on top of the
-built-in `recommended` pack — and a `./.leash.yaml` in the working directory is
-picked up automatically.
+`leash` is a single binary with a handful of subcommands. Every evaluation
+layers rulepacks in the same order: the built-in `recommended` pack, then any
+packs installed with [`leash add`](#leash-add), then a `./.leash.yaml` in the
+working directory (picked up automatically), then the global `--rules <file>`
+flag ([rulepack reference](rules.md)).
 
 ## `leash init`
 
@@ -17,6 +18,60 @@ leash init --global   # global  — ~/.claude/settings.json
 
 Idempotent and non-destructive: it preserves existing settings and won't add the
 hook twice. Restart Claude Code (or start a new session) to activate it.
+
+## `leash search`
+
+Discover rulepacks published in the [registry](registry.md). With no query,
+lists everything; installed packs are marked.
+
+```console
+$ leash search terraform
+terraform-safety 1.0.0
+    Block terraform destroy; confirm state mutations and unreviewed applies
+```
+
+| Flag | Meaning |
+|---|---|
+| `--registry <url or path>` | read a different registry index |
+
+## `leash add`
+
+Install a rulepack from the registry. The pack's sha256 is verified against
+the index before anything is written; installed packs land in
+`~/.leash/packs/` and are active everywhere leash runs — no per-project setup,
+no restart.
+
+```console
+$ leash add terraform-safety
+Installed terraform-safety 1.0.0 (5 rules) — active on every tool call from now on.
+```
+
+| Flag | Meaning |
+|---|---|
+| `--registry <url or path>` | install from a different registry index |
+
+## `leash update`
+
+Re-read the registry and reinstall any installed packs whose published
+checksum changed — all of them, or just the ones you name. Never removes a
+pack, and never lets one registry replace a pack installed from another.
+
+```bash
+leash update                    # everything
+leash update terraform-safety   # just one
+```
+
+| Flag | Meaning |
+|---|---|
+| `--registry <url or path>` | update from a different registry index |
+
+## `leash remove`
+
+Uninstall a pack installed with `leash add`.
+
+```bash
+leash remove terraform-safety
+```
 
 ## `leash check`
 
@@ -69,5 +124,6 @@ leash version
 
 ---
 
-See [Rules](rules.md) for writing and layering rulepacks, and
-[Architecture](architecture.md) for how a decision is produced.
+See [Rules](rules.md) for writing and layering rulepacks, the
+[Registry](registry.md) for sharing them, and [Architecture](architecture.md)
+for how a decision is produced.

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -1,0 +1,170 @@
+# The rulepack registry
+
+Rulepacks are shareable guardrails: one YAML file that layers on the built-in
+`recommended` pack. The registry is how they travel — publish a pack once,
+and anyone gets it with one command:
+
+```bash
+leash search terraform          # discover
+leash add terraform-safety      # install — active on the next tool call
+```
+
+This registry is deliberately **not** a package manager for code: a pack is
+declarative YAML rules, never executable content. (It is also unrelated to the
+`install-from-non-registry-source` rule, which is about npm/pip *package*
+registries.)
+
+## Consuming packs
+
+```bash
+leash search [query]        # list published packs (name, description, tags)
+leash add <pack>            # fetch, verify checksum, install
+leash update [pack...]      # re-install whatever the registry has newer
+leash remove <pack>         # uninstall
+```
+
+Installed packs live in `~/.leash/packs/` and are **globally active**: every
+`leash check` and every agent hook evaluation layers them on the recommended
+pack, in this order:
+
+```
+recommended  <  installed packs (a-z)  <  ./.leash.yaml  <  --rules <file>
+```
+
+Later packs win where they overlap (`overrides`, `default`), and when several
+rules match one action the most severe effect still wins. Nothing here weakens
+the recommended pack unless a pack you chose to install explicitly overrides
+one of its rules — and `leash check` will name the pack that did
+(`rule: … · from <pack>`).
+
+A broken installed pack can never take your protection down: it is skipped
+with a stderr warning and every other pack keeps working.
+
+### Integrity — what the checksum does and doesn't do
+
+`leash add` and `leash update` verify each pack's **sha256 against the index**
+before anything touches disk, and validate that it parses as a rulepack. That
+protects against transport corruption and a tampered pack file.
+
+It does **not** make the registry itself trustworthy: whoever controls the
+index controls the checksums in it. The default registry lives in the Leash
+repo and changes only by reviewed pull request; if you point `--registry`
+somewhere else, you are trusting that source the same way you trust any
+`--rules` file you pass by hand. Packs are inert YAML either way — the blast
+radius of a malicious pack is bad *rules* (e.g. silencing an ask), not code
+execution. Once installed, packs are yours: dev-owned files you can read,
+edit, or delete — in keeping with what Leash is (local self-protection, not
+central enforcement).
+
+## Composing packs with `extends:`
+
+Any rulepack — including `./.leash.yaml` — can pull other packs in
+underneath itself:
+
+```yaml
+# .leash.yaml
+name: my-project
+extends:
+  - terraform-safety        # an installed pack, by name
+  - ./team/base-rules.yaml  # or a file, relative to this file
+overrides:
+  terraform-destroy: ask    # this file has the last word over what it extends
+```
+
+Semantics:
+
+- **A bare name** resolves to an installed pack (`~/.leash/packs/<name>.yaml`);
+  a reference with a `/` or a `.yaml`/`.yml` suffix is a file path, resolved
+  relative to the file that declares it.
+- **Extended packs layer below the extending file**, so its `rules`,
+  `overrides`, and `default` win.
+- **Missing target?** Leash warns with the fix (`run: leash add <name>`),
+  skips that reference, and keeps everything else running.
+- **Cycles and diamonds** are handled: a pack reached twice loads once, and a
+  circular reference is skipped with a warning.
+
+Committing a `.leash.yaml` with `extends:` is how a team shares a baseline:
+teammates run `leash add <pack>` once, and the project file pins the
+composition from then on.
+
+## Authoring a pack
+
+A pack is a normal rulepack file — same schema as `.leash.yaml`
+([full reference](rules.md)):
+
+```yaml
+name: terraform-safety        # must match its registry name
+rules:
+  - id: terraform-destroy    # prefix ids with your pack's theme: no collisions
+    description: terraform destroy tears down live infrastructure
+    severity: critical
+    effect: deny
+    message: Blocked by terraform-safety. Run it yourself if you mean it.
+    match:
+      shell:
+        command_in: [terraform, tofu]
+      regex: '\b(terraform|tofu)\b(\s+-\S+)*\s+destroy\b'
+```
+
+Guidelines that keep packs worth installing:
+
+- **Hold the false-positive line.** `deny` only what is almost never
+  intentional; prefer `ask` for anything a developer might mean; leave the
+  everyday untouched. A pack that cries wolf gets removed.
+- **Prefix rule ids** with the pack's theme (`terraform-*`, `k8s-*`) so two
+  packs never collide. Colliding ids still work, but every engine build warns.
+- **Write the `message` for the person interrupted by it** — say why, and
+  what to do instead.
+
+Test the pack locally before publishing — no registry involved:
+
+```bash
+leash check --rules ./my-pack.yaml 'terraform destroy'    # should catch
+leash check --rules ./my-pack.yaml 'terraform plan'       # must stay ALLOW
+```
+
+## Publishing to the registry
+
+The registry is static files in the Leash repo — publishing is a pull request:
+
+1. Fork [`hoophq/leash`](https://github.com/hoophq/leash) and add your pack as
+   `registry/packs/<name>.yaml`.
+2. Compute its checksum: `shasum -a 256 registry/packs/<name>.yaml`
+3. Add an entry to `registry/index.yaml`:
+
+   ```yaml
+   - name: <name>
+     description: One line that earns the install
+     version: "1.0.0"
+     sha256: <the checksum>
+     path: packs/<name>.yaml
+     tags: [a, few, keywords]
+     maintainer: <you>
+   ```
+
+4. Open the PR. CI re-verifies every checksum and loads every pack against the
+   recommended pack (no id collisions, no warnings) — a stale sha256 fails the
+   build, not someone's install.
+
+Ship an update by editing the pack, bumping `version`, and recomputing
+`sha256`. Users pick it up with `leash update`. The index is read live off
+`main`, so a merged PR is published — no release needed.
+
+## Self-hosting a registry
+
+`--registry` points the commands at any index — an HTTPS URL or a local path:
+
+```bash
+leash add my-pack --registry https://example.com/leash/index.yaml
+leash add my-pack --registry ./my-registry/index.yaml    # e.g. a checkout
+```
+
+An index is just `index.yaml` (`schema: 1`, a `packs:` list as above) with
+pack `path`s resolved relative to it. A git repo, an S3 bucket, or a directory
+all work. Air-gapped teams can vendor the whole registry and point at the
+checkout.
+
+---
+
+See [Rules](rules.md) for the full match reference, and
+[CLI](cli.md) for every command and flag.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -7,6 +7,8 @@ conditions, and how to retune the built-in rules.
 ## How rulepacks layer
 
 - The embedded **`recommended`** pack is always active.
+- Packs installed with **[`leash add`](registry.md)** layer next — active in
+  every project, no setup.
 - Drop a **`./.leash.yaml`** in your project (auto-discovered) or pass
   **`--rules <file>`** to layer your own rules on top.
 - When several rules match one command, the **most severe effect wins**:
@@ -81,6 +83,24 @@ Matched against semantic facts from the shell parser — not the raw text.
 | Field | Fires on |
 |---|---|
 | `url_regex` | a regexp against the fetched URL |
+
+## Extending another pack
+
+Any rulepack can pull other packs in underneath itself with `extends:` — an
+installed pack by name, or a file by path (relative to the file declaring it):
+
+```yaml
+extends:
+  - terraform-safety        # installed with `leash add`
+  - ./team/base-rules.yaml  # a file next to this one
+overrides:
+  terraform-destroy: ask    # this file wins over what it extends
+```
+
+The extending file layers **on top** of what it pulls in, a pack reached twice
+loads once, and a missing target degrades to a warning with the fix
+(`run: leash add <name>`) — it never takes the engine down.
+**→ [Composition semantics, in depth](registry.md)**
 
 ## Overriding a built-in rule's effect
 

--- a/internal/cli/add.go
+++ b/internal/cli/add.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/hoophq/leash/internal/policy"
+	"github.com/hoophq/leash/internal/registry"
+	"github.com/hoophq/leash/internal/store"
+	"github.com/spf13/cobra"
+)
+
+func newAddCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add <pack>",
+		Short: "Install a rulepack from the registry",
+		Long: "Fetches a published rulepack, verifies its checksum against the registry\n" +
+			"index, and installs it under ~/.leash/packs. Installed packs layer on the\n" +
+			"recommended pack everywhere leash runs — no per-project setup.\n\n" +
+			"Discover packs with `leash search`.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			st, err := openStore()
+			if err != nil {
+				return fail(cmd, err)
+			}
+			if err := runAdd(cmd.OutOrStdout(), st, registry.NewClient(registryLocation), args[0]); err != nil {
+				return fail(cmd, err)
+			}
+			return nil
+		},
+	}
+	addRegistryFlag(cmd)
+	return cmd
+}
+
+func runAdd(out io.Writer, st *store.Store, client *registry.Client, name string) error {
+	idx, err := fetchIndex(client)
+	if err != nil {
+		return err
+	}
+	entry, ok := idx.Find(name)
+	if !ok {
+		return fmt.Errorf("pack %q not found in the registry (try: leash search)", name)
+	}
+	data, err := client.FetchPack(entry)
+	if err != nil {
+		return err
+	}
+	pack, err := st.Install(name, data)
+	if err != nil {
+		return err
+	}
+	if err := writeLock(st, name, entry, client.Location()); err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "Installed %s %s (%d rules) — active on every tool call from now on.\n",
+		name, entry.Version, len(pack.Rules))
+
+	// Surface a missing extends target now, not at the next tool call.
+	res := policy.NewResolver(st.Locate)
+	if err := res.Add(st.PackPath(name)); err == nil {
+		fprintWarnings(out, res.Warnings())
+	}
+	return nil
+}

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -103,7 +103,11 @@ func printDecision(cmd *cobra.Command, a policy.Action, d policy.Decision) {
 		if sev == "" {
 			sev = "—"
 		}
-		fmt.Fprintf(out, "  %s %s (%s)\n", c.dim("rule:"), d.Rule.ID, sev)
+		provenance := ""
+		if p := d.Rule.Pack(); p != "" && p != policy.RecommendedName {
+			provenance = c.dim(" · from " + p)
+		}
+		fmt.Fprintf(out, "  %s %s (%s)%s\n", c.dim("rule:"), d.Rule.ID, sev, provenance)
 		if msg := ruleText(d.Rule); msg != "" {
 			fmt.Fprintf(out, "  %s\n", c.dim(wrap(msg, 72, "  ")))
 		}

--- a/internal/cli/registry.go
+++ b/internal/cli/registry.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/hoophq/leash/internal/registry"
+	"github.com/hoophq/leash/internal/store"
+	"github.com/spf13/cobra"
+)
+
+// registryLocation is where the registry commands (add, search, update) read
+// the index from — the built-in registry unless --registry overrides it.
+var registryLocation string
+
+func addRegistryFlag(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&registryLocation, "registry", registry.DefaultIndexURL,
+		"registry index to read (an https URL or a local path)")
+}
+
+// openStore returns the user-level store (~/.leash) the registry commands
+// operate on. Unlike the engine path, these commands are explicit and loud:
+// no store, no command.
+func openStore() (*store.Store, error) {
+	dir, err := store.DefaultDir()
+	if err != nil {
+		return nil, err
+	}
+	return store.Open(dir), nil
+}
+
+// fetchIndex reads the registry index, wrapping failures with the one context
+// every command wants.
+func fetchIndex(client *registry.Client) (*registry.Index, error) {
+	idx, err := client.Index()
+	if err != nil {
+		return nil, fmt.Errorf("fetch registry index: %w", err)
+	}
+	return idx, nil
+}
+
+// writeLock records where an installed pack came from. The lockfile is
+// metadata only — a failure here never undoes an install.
+func writeLock(st *store.Store, name string, e registry.Entry, source string) error {
+	lf, err := st.Lockfile()
+	if err != nil {
+		return err
+	}
+	lf.Packs[name] = store.NewLockEntry(e.Version, e.SHA256, source)
+	return st.SaveLockfile(lf)
+}
+
+// removeLock drops a pack's lockfile entry.
+func removeLock(st *store.Store, name string) error {
+	lf, err := st.Lockfile()
+	if err != nil {
+		return err
+	}
+	delete(lf.Packs, name)
+	return st.SaveLockfile(lf)
+}
+
+func fprintWarnings(out io.Writer, warnings []string) {
+	for _, w := range warnings {
+		fmt.Fprintf(out, "note: %s\n", w)
+	}
+}

--- a/internal/cli/registry_test.go
+++ b/internal/cli/registry_test.go
@@ -1,0 +1,304 @@
+package cli
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hoophq/leash/internal/registry"
+	"github.com/hoophq/leash/internal/store"
+)
+
+const fixturePackV1 = `name: fixture
+rules:
+  - id: fixture-rule
+    description: test
+    effect: ask
+    match:
+      regex: 'zzz-fixture'
+`
+
+const fixturePackV2 = `name: fixture
+rules:
+  - id: fixture-rule
+    description: test v2
+    effect: deny
+    match:
+      regex: 'zzz-fixture'
+`
+
+func hexSum(data string) string {
+	sum := sha256.Sum256([]byte(data))
+	return hex.EncodeToString(sum[:])
+}
+
+// fakeRegistry writes a local registry with one pack and returns its index
+// path. sum lets a test publish a deliberately wrong checksum.
+func fakeRegistry(t *testing.T, packYAML, version, sum string) string {
+	t.Helper()
+	return publishFixture(t, t.TempDir(), packYAML, version, sum)
+}
+
+// publishFixture (re)writes the fixture pack and index in dir — calling it
+// twice on one dir models a new version published to the same registry.
+func publishFixture(t *testing.T, dir, packYAML, version, sum string) string {
+	t.Helper()
+	writeTestFile(t, filepath.Join(dir, "packs", "fixture.yaml"), packYAML)
+	index := fmt.Sprintf(`schema: 1
+packs:
+  - name: fixture
+    description: A fixture pack
+    version: %q
+    sha256: %s
+    path: packs/fixture.yaml
+    tags: [testing]
+`, version, sum)
+	return writeTestFile(t, filepath.Join(dir, "index.yaml"), index)
+}
+
+func TestRunAdd(t *testing.T) {
+	st := store.Open(t.TempDir())
+	index := fakeRegistry(t, fixturePackV1, "1.0.0", hexSum(fixturePackV1))
+
+	var out bytes.Buffer
+	if err := runAdd(&out, st, registry.NewClient(index), "fixture"); err != nil {
+		t.Fatal(err)
+	}
+	if !st.Has("fixture") {
+		t.Fatal("pack not installed")
+	}
+	if !strings.Contains(out.String(), "Installed fixture 1.0.0") {
+		t.Fatalf("output = %q, want an install confirmation", out.String())
+	}
+
+	lf, err := st.Lockfile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry, ok := lf.Packs["fixture"]
+	if !ok || entry.Version != "1.0.0" || entry.SHA256 != hexSum(fixturePackV1) || entry.Source != index {
+		t.Fatalf("lock entry = %+v, %v", entry, ok)
+	}
+}
+
+func TestRunAddRejectsChecksumMismatchAndWritesNothing(t *testing.T) {
+	st := store.Open(t.TempDir())
+	index := fakeRegistry(t, fixturePackV1, "1.0.0", hexSum("tampered"))
+
+	err := runAdd(&bytes.Buffer{}, st, registry.NewClient(index), "fixture")
+	if err == nil || !strings.Contains(err.Error(), "checksum") {
+		t.Fatalf("want a checksum error, got %v", err)
+	}
+	if st.Has("fixture") {
+		t.Fatal("nothing may be installed on checksum mismatch")
+	}
+}
+
+func TestRunAddUnknownPack(t *testing.T) {
+	st := store.Open(t.TempDir())
+	index := fakeRegistry(t, fixturePackV1, "1.0.0", hexSum(fixturePackV1))
+	err := runAdd(&bytes.Buffer{}, st, registry.NewClient(index), "nope")
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("want a not-found error, got %v", err)
+	}
+}
+
+func TestRunSearch(t *testing.T) {
+	st := store.Open(t.TempDir())
+	index := fakeRegistry(t, fixturePackV1, "1.0.0", hexSum(fixturePackV1))
+
+	var out bytes.Buffer
+	if err := runSearch(&out, st, registry.NewClient(index), ""); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "fixture 1.0.0") || strings.Contains(out.String(), "(installed)") {
+		t.Fatalf("output = %q, want the pack listed and not marked installed", out.String())
+	}
+
+	// After an install, the marker appears.
+	if err := runAdd(&bytes.Buffer{}, st, registry.NewClient(index), "fixture"); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	if err := runSearch(&out, st, registry.NewClient(index), "fixture"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "(installed)") {
+		t.Fatalf("output = %q, want an (installed) marker", out.String())
+	}
+
+	// A query that matches nothing says so.
+	out.Reset()
+	if err := runSearch(&out, st, registry.NewClient(index), "zzz-nope"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "No packs match") {
+		t.Fatalf("output = %q, want a no-match message", out.String())
+	}
+}
+
+func TestRunRemove(t *testing.T) {
+	st := store.Open(t.TempDir())
+	index := fakeRegistry(t, fixturePackV1, "1.0.0", hexSum(fixturePackV1))
+	if err := runAdd(&bytes.Buffer{}, st, registry.NewClient(index), "fixture"); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	if err := runRemove(&out, st, "fixture"); err != nil {
+		t.Fatal(err)
+	}
+	if st.Has("fixture") {
+		t.Fatal("pack still installed after remove")
+	}
+	lf, err := st.Lockfile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := lf.Packs["fixture"]; ok {
+		t.Fatal("lock entry not cleaned up")
+	}
+
+	if err := runRemove(&out, st, "fixture"); err == nil {
+		t.Fatal("want an error removing a pack that is not installed")
+	}
+}
+
+func TestRunUpdate(t *testing.T) {
+	st := store.Open(t.TempDir())
+	dir := t.TempDir()
+	index := publishFixture(t, dir, fixturePackV1, "1.0.0", hexSum(fixturePackV1))
+	if err := runAdd(&bytes.Buffer{}, st, registry.NewClient(index), "fixture"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Same registry content: up to date.
+	var out bytes.Buffer
+	if err := runUpdate(&out, st, registry.NewClient(index), nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "up to date") {
+		t.Fatalf("output = %q, want up to date", out.String())
+	}
+
+	// v2 published to the same registry: update reinstalls, rewrites the lock.
+	publishFixture(t, dir, fixturePackV2, "2.0.0", hexSum(fixturePackV2))
+	out.Reset()
+	if err := runUpdate(&out, st, registry.NewClient(index), nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "1.0.0 -> 2.0.0") {
+		t.Fatalf("output = %q, want a version bump", out.String())
+	}
+	lf, err := st.Lockfile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lf.Packs["fixture"].Version != "2.0.0" {
+		t.Fatalf("lock version = %q, want 2.0.0", lf.Packs["fixture"].Version)
+	}
+	data, err := os.ReadFile(st.PackPath("fixture"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != fixturePackV2 {
+		t.Fatal("pack file not updated to v2")
+	}
+}
+
+func TestRunUpdateExplicitUnknownName(t *testing.T) {
+	st := store.Open(t.TempDir())
+	index := fakeRegistry(t, fixturePackV1, "1.0.0", hexSum(fixturePackV1))
+	err := runUpdate(&bytes.Buffer{}, st, registry.NewClient(index), []string{"ghost"})
+	if err == nil || !strings.Contains(err.Error(), "not installed") {
+		t.Fatalf("want a not-installed error, got %v", err)
+	}
+}
+
+func TestRunUpdateNothingInstalled(t *testing.T) {
+	st := store.Open(t.TempDir())
+	index := fakeRegistry(t, fixturePackV1, "1.0.0", hexSum(fixturePackV1))
+	var out bytes.Buffer
+	if err := runUpdate(&out, st, registry.NewClient(index), nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "nothing to update") {
+		t.Fatalf("output = %q, want nothing-to-update", out.String())
+	}
+}
+
+func TestRunUpdateKeepsPackDroppedFromRegistry(t *testing.T) {
+	st := store.Open(t.TempDir())
+	index := fakeRegistry(t, fixturePackV1, "1.0.0", hexSum(fixturePackV1))
+	if err := runAdd(&bytes.Buffer{}, st, registry.NewClient(index), "fixture"); err != nil {
+		t.Fatal(err)
+	}
+
+	empty := writeTestFile(t, filepath.Join(t.TempDir(), "index.yaml"), "schema: 1\npacks: []\n")
+	var out bytes.Buffer
+	if err := runUpdate(&out, st, registry.NewClient(empty), nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "kept as-is") {
+		t.Fatalf("output = %q, want kept as-is", out.String())
+	}
+	if !st.Has("fixture") {
+		t.Fatal("a pack must never be removed by update")
+	}
+}
+
+// A same-named pack in a different registry is a different pack — a bare
+// `leash update` against the wrong registry must never replace it.
+func TestRunUpdateRefusesCrossRegistryReplacement(t *testing.T) {
+	st := store.Open(t.TempDir())
+	indexA := fakeRegistry(t, fixturePackV1, "1.0.0", hexSum(fixturePackV1))
+	if err := runAdd(&bytes.Buffer{}, st, registry.NewClient(indexA), "fixture"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Another registry publishes its own pack under the same name.
+	indexB := fakeRegistry(t, fixturePackV2, "9.9.9", hexSum(fixturePackV2))
+	var out bytes.Buffer
+	if err := runUpdate(&out, st, registry.NewClient(indexB), nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "different registry") {
+		t.Fatalf("output = %q, want a different-registry notice", out.String())
+	}
+	data, err := os.ReadFile(st.PackPath("fixture"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != fixturePackV1 {
+		t.Fatal("update replaced a pack installed from another registry")
+	}
+}
+
+func TestRunUpdateSkipsUnmanagedPack(t *testing.T) {
+	st := store.Open(t.TempDir())
+	// Hand-dropped pack: present on disk, absent from the lockfile.
+	if _, err := st.Install("fixture", []byte(fixturePackV1)); err != nil {
+		t.Fatal(err)
+	}
+	index := fakeRegistry(t, fixturePackV2, "2.0.0", hexSum(fixturePackV2))
+
+	var out bytes.Buffer
+	if err := runUpdate(&out, st, registry.NewClient(index), nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "leash add fixture to adopt") {
+		t.Fatalf("output = %q, want an adopt hint", out.String())
+	}
+	data, err := os.ReadFile(st.PackPath("fixture"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != fixturePackV1 {
+		t.Fatal("update must not overwrite a pack it does not manage")
+	}
+}

--- a/internal/cli/remove.go
+++ b/internal/cli/remove.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/hoophq/leash/internal/store"
+	"github.com/spf13/cobra"
+)
+
+func newRemoveCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "remove <pack>",
+		Short: "Uninstall a rulepack installed with `leash add`",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			st, err := openStore()
+			if err != nil {
+				return fail(cmd, err)
+			}
+			if err := runRemove(cmd.OutOrStdout(), st, args[0]); err != nil {
+				return fail(cmd, err)
+			}
+			return nil
+		},
+	}
+}
+
+func runRemove(out io.Writer, st *store.Store, name string) error {
+	if err := st.Remove(name); err != nil {
+		return err
+	}
+	// The pack file is gone — protection already changed. The lockfile is
+	// metadata; a problem there is a note, not a failure.
+	if err := removeLock(st, name); err != nil {
+		fmt.Fprintf(out, "note: could not update lockfile: %v\n", err)
+	}
+	fmt.Fprintf(out, "Removed %s\n", name)
+	return nil
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -3,10 +3,12 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
 	"github.com/hoophq/leash/internal/policy"
+	"github.com/hoophq/leash/internal/store"
 	"github.com/spf13/cobra"
 )
 
@@ -33,38 +35,84 @@ func NewRootCommand(version string) *cobra.Command {
 		newCheckCommand(),
 		newHookCommand(),
 		newInitCommand(),
+		newAddCommand(),
+		newSearchCommand(),
+		newRemoveCommand(),
+		newUpdateCommand(),
 		newVersionCommand(version),
 	)
 	return root
 }
 
-// buildEngine assembles the policy engine: the embedded recommended pack, plus
-// an auto-discovered project rulepack (./.leash.yaml), plus an explicit --rules
-// file if given. Later packs layer on top of earlier ones.
+// buildEngine assembles the policy engine: the embedded recommended pack, the
+// packs installed with `leash add` (~/.leash/packs), an auto-discovered
+// project rulepack (./.leash.yaml), and an explicit --rules file if given.
+// Later packs layer on top of earlier ones, and any pack can pull others in
+// with extends:.
 func buildEngine() (*policy.Engine, error) {
-	packs := []*policy.Rulepack{policy.Recommended()}
+	var st *store.Store
+	dir, err := store.DefaultDir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "leash: skipping installed packs: %v\n", err)
+	} else {
+		st = store.Open(dir)
+	}
+	return buildEngineWithStore(st, rulesFile, os.Stderr)
+}
+
+// buildEngineWithStore is buildEngine with its inputs injected for tests.
+// Ambient sources — installed packs and the discovered .leash.yaml — degrade:
+// one that fails to load is skipped with a warning so the rest keep
+// protecting. The explicit --rules file stays a hard error: the user asked
+// for it by name.
+func buildEngineWithStore(st *store.Store, rulesFile string, errw io.Writer) (*policy.Engine, error) {
+	res := policy.NewResolver(locator(st))
+	var warnings []string
+
+	if st != nil {
+		names, err := st.List()
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("reading installed packs: %v (skipped)", err))
+		}
+		for _, name := range names {
+			path, ok := st.Locate(name)
+			if !ok {
+				continue
+			}
+			if err := res.Add(path); err != nil {
+				warnings = append(warnings, fmt.Sprintf("installed pack %q: %v (skipped)", name, err))
+			}
+		}
+	}
 
 	if discovered := discoverProjectRules(); discovered != "" {
-		pack, err := policy.LoadFile(discovered)
-		if err != nil {
-			return nil, err
+		if err := res.Add(discovered); err != nil {
+			warnings = append(warnings, fmt.Sprintf("%v (skipped)", err))
 		}
-		packs = append(packs, pack)
 	}
 
 	if rulesFile != "" {
-		pack, err := policy.LoadFile(rulesFile)
-		if err != nil {
+		if err := res.Add(rulesFile); err != nil {
 			return nil, err
 		}
-		packs = append(packs, pack)
 	}
 
+	packs := append([]*policy.Rulepack{policy.Recommended()}, res.Packs()...)
 	engine := policy.NewEngine(packs...)
-	for _, w := range engine.Warnings() {
-		fmt.Fprintf(os.Stderr, "leash: %s\n", w)
+	warnings = append(warnings, res.Warnings()...)
+	warnings = append(warnings, engine.Warnings()...)
+	for _, w := range warnings {
+		fmt.Fprintf(errw, "leash: %s\n", w)
 	}
 	return engine, nil
+}
+
+// locator adapts a possibly-nil store to a policy.LocateFunc.
+func locator(st *store.Store) policy.LocateFunc {
+	if st == nil {
+		return nil
+	}
+	return st.Locate
 }
 
 func discoverProjectRules() string {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -1,0 +1,204 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hoophq/leash/internal/policy"
+	"github.com/hoophq/leash/internal/store"
+)
+
+func writeTestFile(t *testing.T, path, content string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func evalShell(t *testing.T, e *policy.Engine, command string) policy.Effect {
+	t.Helper()
+	return e.Evaluate(policy.Action{Kind: policy.ActionShell, Command: command, Cwd: "/w"}).Effect
+}
+
+// chdirEmpty moves the test into an empty directory so a real ./.leash.yaml
+// can never leak into discovery.
+func chdirEmpty(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Chdir(dir)
+	return dir
+}
+
+func TestBuildEngineNoStoreStillProtects(t *testing.T) {
+	chdirEmpty(t)
+	e, err := buildEngineWithStore(nil, "", &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := evalShell(t, e, "rm -rf ~"); got != policy.EffectDeny {
+		t.Fatalf("rm -rf ~ = %q, want deny", got)
+	}
+}
+
+func TestBuildEngineInstalledPackFires(t *testing.T) {
+	chdirEmpty(t)
+	st := store.Open(t.TempDir())
+	if _, err := st.Install("team", []byte(`name: team
+rules:
+  - id: team-marker
+    description: test
+    effect: deny
+    match:
+      regex: 'zzz-team-marker'
+`)); err != nil {
+		t.Fatal(err)
+	}
+
+	e, err := buildEngineWithStore(st, "", &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := evalShell(t, e, "echo zzz-team-marker"); got != policy.EffectDeny {
+		t.Fatalf("installed pack rule = %q, want deny", got)
+	}
+	// Recommended still layered underneath.
+	if got := evalShell(t, e, "rm -rf ~"); got != policy.EffectDeny {
+		t.Fatalf("rm -rf ~ = %q, want deny", got)
+	}
+}
+
+func TestBuildEngineCorruptInstalledPackDegrades(t *testing.T) {
+	chdirEmpty(t)
+	st := store.Open(t.TempDir())
+	if _, err := st.Install("good", []byte(`name: good
+rules:
+  - id: good-marker
+    description: test
+    effect: ask
+    match:
+      regex: 'zzz-good-marker'
+`)); err != nil {
+		t.Fatal(err)
+	}
+	// A pack corrupted on disk after install (Install would reject it).
+	writeTestFile(t, st.PackPath("broken"), "rules:\n  - id: x\n    effect: nope\n")
+
+	var stderr bytes.Buffer
+	e, err := buildEngineWithStore(st, "", &stderr)
+	if err != nil {
+		t.Fatalf("a corrupt installed pack must not abort the engine: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "broken") {
+		t.Fatalf("want a warning naming the broken pack, got %q", stderr.String())
+	}
+	// The rest of the protection still stands.
+	if got := evalShell(t, e, "rm -rf ~"); got != policy.EffectDeny {
+		t.Fatalf("rm -rf ~ = %q, want deny", got)
+	}
+	if got := evalShell(t, e, "echo zzz-good-marker"); got != policy.EffectAsk {
+		t.Fatalf("good pack rule = %q, want ask", got)
+	}
+}
+
+func TestBuildEngineCorruptProjectRulesDegrade(t *testing.T) {
+	dir := chdirEmpty(t)
+	writeTestFile(t, filepath.Join(dir, ".leash.yaml"), "rules:\n  - id: x\n    effect: nope\n")
+
+	var stderr bytes.Buffer
+	e, err := buildEngineWithStore(nil, "", &stderr)
+	if err != nil {
+		t.Fatalf("a corrupt .leash.yaml must not abort the engine: %v", err)
+	}
+	if stderr.Len() == 0 {
+		t.Fatal("want a warning about the corrupt .leash.yaml")
+	}
+	if got := evalShell(t, e, "rm -rf ~"); got != policy.EffectDeny {
+		t.Fatalf("rm -rf ~ = %q, want deny", got)
+	}
+}
+
+func TestBuildEngineCorruptRulesFlagIsLoud(t *testing.T) {
+	chdirEmpty(t)
+	bad := writeTestFile(t, filepath.Join(t.TempDir(), "bad.yaml"), "rules:\n  - id: x\n    effect: nope\n")
+	if _, err := buildEngineWithStore(nil, bad, &bytes.Buffer{}); err == nil {
+		t.Fatal("an explicit --rules file that fails to load must be an error")
+	}
+}
+
+// Layering order: recommended < installed < .leash.yaml < --rules.
+func TestBuildEngineLayeringOrder(t *testing.T) {
+	dir := chdirEmpty(t)
+	st := store.Open(t.TempDir())
+	// Installed pack softens the recommended force-push ask to allow…
+	if _, err := st.Install("soften", []byte("name: soften\noverrides:\n  git-force-push: allow\n")); err != nil {
+		t.Fatal(err)
+	}
+	// …the project pack re-hardens it to ask…
+	writeTestFile(t, filepath.Join(dir, ".leash.yaml"), "name: project\noverrides:\n  git-force-push: ask\n")
+	// …and the --rules file has the last word: deny.
+	rules := writeTestFile(t, filepath.Join(t.TempDir(), "rules.yaml"), "name: flag\noverrides:\n  git-force-push: deny\n")
+
+	e, err := buildEngineWithStore(st, rules, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := evalShell(t, e, "git push --force"); got != policy.EffectDeny {
+		t.Fatalf("git push --force = %q, want deny (--rules layers last)", got)
+	}
+}
+
+// A .leash.yaml can extend an installed pack by name.
+func TestBuildEngineProjectExtendsInstalledPack(t *testing.T) {
+	dir := chdirEmpty(t)
+	st := store.Open(t.TempDir())
+	if _, err := st.Install("base", []byte(`name: base
+rules:
+  - id: base-marker
+    description: test
+    effect: deny
+    match:
+      regex: 'zzz-base-marker'
+`)); err != nil {
+		t.Fatal(err)
+	}
+	// Remove it from ambient activation? No — installed packs are always
+	// active; extends from the project just also pins it. Both paths must
+	// dedupe to a single load.
+	writeTestFile(t, filepath.Join(dir, ".leash.yaml"), "name: project\nextends: [base]\noverrides:\n  base-marker: ask\n")
+
+	var stderr bytes.Buffer
+	e, err := buildEngineWithStore(st, "", &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := evalShell(t, e, "echo zzz-base-marker"); got != policy.EffectAsk {
+		t.Fatalf("effect = %q, want ask (project override wins over extended base)", got)
+	}
+	if strings.Contains(stderr.String(), "defined by both") {
+		t.Fatalf("extends of an installed pack must dedupe, got %q", stderr.String())
+	}
+}
+
+func TestBuildEngineMissingExtendsTargetWarns(t *testing.T) {
+	dir := chdirEmpty(t)
+	writeTestFile(t, filepath.Join(dir, ".leash.yaml"), "name: project\nextends: [ghost]\n")
+
+	var stderr bytes.Buffer
+	e, err := buildEngineWithStore(store.Open(t.TempDir()), "", &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stderr.String(), "leash add ghost") {
+		t.Fatalf("want a `leash add ghost` hint, got %q", stderr.String())
+	}
+	if got := evalShell(t, e, "rm -rf ~"); got != policy.EffectDeny {
+		t.Fatalf("rm -rf ~ = %q, want deny", got)
+	}
+}

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/hoophq/leash/internal/registry"
+	"github.com/hoophq/leash/internal/store"
+	"github.com/spf13/cobra"
+)
+
+func newSearchCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "search [query]",
+		Short: "Discover rulepacks published in the registry",
+		Long: "Lists packs from the registry index, filtered by a query against name,\n" +
+			"description, and tags. With no query, lists everything.",
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			query := ""
+			if len(args) == 1 {
+				query = args[0]
+			}
+			st, _ := openStore() // best-effort: only used to mark installed packs
+			if err := runSearch(cmd.OutOrStdout(), st, registry.NewClient(registryLocation), query); err != nil {
+				return fail(cmd, err)
+			}
+			return nil
+		},
+	}
+	addRegistryFlag(cmd)
+	return cmd
+}
+
+func runSearch(out io.Writer, st *store.Store, client *registry.Client, query string) error {
+	idx, err := fetchIndex(client)
+	if err != nil {
+		return err
+	}
+	entries := idx.Search(query)
+	if len(entries) == 0 {
+		if query == "" {
+			fmt.Fprintln(out, "The registry has no packs yet.")
+		} else {
+			fmt.Fprintf(out, "No packs match %q.\n", query)
+		}
+		return nil
+	}
+
+	c := newColors(out)
+	for _, e := range entries {
+		line := fmt.Sprintf("%s %s", e.Name, e.Version)
+		if st != nil && st.Has(e.Name) {
+			line += " " + c.dim("(installed)")
+		}
+		fmt.Fprintln(out, line)
+		if e.Description != "" {
+			fmt.Fprintf(out, "    %s\n", c.dim(wrap(collapse(e.Description), 72, "    ")))
+		}
+	}
+	fmt.Fprintf(out, "\n%s\n", c.dim("install one with: leash add <pack>"))
+	return nil
+}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/hoophq/leash/internal/registry"
+	"github.com/hoophq/leash/internal/store"
+	"github.com/spf13/cobra"
+)
+
+func newUpdateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update [pack...]",
+		Short: "Update installed rulepacks to the registry's current versions",
+		Long: "Re-reads the registry index and reinstalls any named packs — or every\n" +
+			"installed pack — whose published checksum changed. Never removes a pack.",
+		Args: cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			st, err := openStore()
+			if err != nil {
+				return fail(cmd, err)
+			}
+			if err := runUpdate(cmd.OutOrStdout(), st, registry.NewClient(registryLocation), args); err != nil {
+				return fail(cmd, err)
+			}
+			return nil
+		},
+	}
+	addRegistryFlag(cmd)
+	return cmd
+}
+
+func runUpdate(out io.Writer, st *store.Store, client *registry.Client, names []string) error {
+	targets, err := updateTargets(st, names)
+	if err != nil {
+		return err
+	}
+	if len(targets) == 0 {
+		fmt.Fprintln(out, "No packs installed — nothing to update.")
+		return nil
+	}
+
+	idx, err := fetchIndex(client)
+	if err != nil {
+		return err
+	}
+	lf, err := st.Lockfile()
+	if err != nil {
+		return err
+	}
+
+	var failed int
+	for _, name := range targets {
+		entry, ok := idx.Find(name)
+		if !ok {
+			fmt.Fprintf(out, "%s: not in this registry (kept as-is)\n", name)
+			continue
+		}
+		locked, managed := lf.Packs[name]
+		if !managed {
+			fmt.Fprintf(out, "%s: not installed from a registry (kept as-is; leash add %s to adopt it)\n", name, name)
+			continue
+		}
+		// A same-named pack in a different registry is not an update — it is
+		// a different pack. Never let one registry replace another's install.
+		if locked.Source != client.Location() {
+			fmt.Fprintf(out, "%s: installed from a different registry (kept as-is; update with: leash update %s --registry %s)\n",
+				name, name, locked.Source)
+			continue
+		}
+		if strings.EqualFold(locked.SHA256, entry.SHA256) {
+			fmt.Fprintf(out, "%s %s: up to date\n", name, entry.Version)
+			continue
+		}
+		data, err := client.FetchPack(entry)
+		if err != nil {
+			fmt.Fprintf(out, "%s: %v (kept at %s)\n", name, err, locked.Version)
+			failed++
+			continue
+		}
+		if _, err := st.Install(name, data); err != nil {
+			fmt.Fprintf(out, "%s: %v (kept at %s)\n", name, err, locked.Version)
+			failed++
+			continue
+		}
+		lf.Packs[name] = store.NewLockEntry(entry.Version, entry.SHA256, client.Location())
+		fmt.Fprintf(out, "%s: %s -> %s\n", name, locked.Version, entry.Version)
+	}
+	if err := st.SaveLockfile(lf); err != nil {
+		return err
+	}
+	if failed > 0 {
+		return fmt.Errorf("%d pack(s) failed to update", failed)
+	}
+	return nil
+}
+
+// updateTargets resolves what to update: the named packs (each must be
+// installed — the user asked for it by name) or everything installed.
+func updateTargets(st *store.Store, names []string) ([]string, error) {
+	if len(names) == 0 {
+		return st.List()
+	}
+	for _, name := range names {
+		if !st.Has(name) {
+			return nil, fmt.Errorf("pack %q is not installed", name)
+		}
+	}
+	return names, nil
+}

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -24,14 +24,16 @@ type Engine struct {
 // appended after earlier ones; the default effect is taken from the last pack
 // that sets one, falling back to allow. Effect overrides from every pack are
 // applied to the pooled rules by id (later packs win); an override that targets
-// an unknown id is recorded as a warning rather than failing. Rulepacks must
-// already be validated (Load/LoadFile do this).
+// an unknown id is recorded as a warning rather than failing, as is a rule id
+// defined by more than one pack. Rulepacks must already be validated
+// (Load/LoadFile do this).
 func NewEngine(packs ...*Rulepack) *Engine {
 	e := &Engine{defaultEffect: EffectAllow}
 	home, _ := os.UserHomeDir()
 	e.home = home
 
 	overrides := map[string]Effect{}
+	definedIn := map[string]string{} // rule id -> pack that first defined it
 	for _, p := range packs {
 		if p == nil {
 			continue
@@ -39,7 +41,22 @@ func NewEngine(packs ...*Rulepack) *Engine {
 		if p.Default != "" {
 			e.defaultEffect = p.Default
 		}
+		name := p.Name
+		if name == "" {
+			name = "(unnamed pack)"
+		}
+		start := len(e.rules)
 		e.rules = append(e.rules, p.Rules...)
+		for i := start; i < len(e.rules); i++ {
+			e.rules[i].pack = name
+			id := e.rules[i].ID
+			if prev, ok := definedIn[id]; ok {
+				e.warnings = append(e.warnings, fmt.Sprintf(
+					"rule id %q is defined by both %q and %q (both stay active)", id, prev, name))
+			} else {
+				definedIn[id] = name
+			}
+		}
 		for id, eff := range p.Overrides {
 			overrides[id] = eff // later packs win
 		}

--- a/internal/policy/provenance_test.go
+++ b/internal/policy/provenance_test.go
@@ -1,0 +1,57 @@
+package policy
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRuleProvenanceStamped(t *testing.T) {
+	user := &Rulepack{Name: "user", Rules: []Rule{{
+		ID: "marker", Effect: EffectDeny, Match: Match{Regex: "zzz-provenance"},
+	}}}
+	if err := user.validate(); err != nil {
+		t.Fatal(err)
+	}
+	e := NewEngine(Recommended(), user)
+
+	d := e.Evaluate(Action{Kind: ActionShell, Command: "echo zzz-provenance", Cwd: "/w"})
+	if d.Rule == nil || d.Rule.Pack() != "user" {
+		t.Fatalf("deciding rule pack = %v, want %q", d.Rule, "user")
+	}
+
+	d = e.Evaluate(Action{Kind: ActionShell, Command: "rm -rf ~", Cwd: "/w"})
+	if d.Rule == nil || d.Rule.Pack() != "recommended" {
+		t.Fatalf("deciding rule pack = %v, want %q", d.Rule, "recommended")
+	}
+}
+
+func TestCrossPackDuplicateRuleIDWarns(t *testing.T) {
+	a := &Rulepack{Name: "pack-a", Rules: []Rule{{
+		ID: "dup", Effect: EffectAsk, Match: Match{Regex: "zzz-dup"},
+	}}}
+	b := &Rulepack{Name: "pack-b", Rules: []Rule{{
+		ID: "dup", Effect: EffectDeny, Match: Match{Regex: "zzz-dup"},
+	}}}
+	for _, p := range []*Rulepack{a, b} {
+		if err := p.validate(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	e := NewEngine(a, b)
+
+	var found bool
+	for _, w := range e.Warnings() {
+		if strings.Contains(w, `"dup"`) && strings.Contains(w, "pack-a") && strings.Contains(w, "pack-b") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("want a duplicate-id warning naming both packs, got %v", e.Warnings())
+	}
+
+	// Both rules stay active: the most severe effect still wins.
+	d := e.Evaluate(Action{Kind: ActionShell, Command: "echo zzz-dup", Cwd: "/w"})
+	if d.Effect != EffectDeny {
+		t.Fatalf("Effect = %q, want deny (both duplicate rules evaluated)", d.Effect)
+	}
+}

--- a/internal/policy/resolve.go
+++ b/internal/policy/resolve.go
@@ -1,0 +1,136 @@
+package policy
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// LocateFunc resolves an installed rulepack name to a file path, reporting
+// ok=false when no pack by that name is installed. A nil LocateFunc never
+// finds anything.
+type LocateFunc func(name string) (path string, ok bool)
+
+// Resolver flattens rulepack files and their extends: chains into the ordered
+// pack list NewEngine expects: every pack a file extends is placed before it,
+// so the extending pack's rules, overrides, and default win under the engine's
+// later-pack-wins semantics. Packs are deduplicated by file identity across
+// all Add calls on one Resolver, and a cyclic reference is skipped rather than
+// followed — both are warnings, never errors, so a bad reference costs only
+// itself, not the engine.
+type Resolver struct {
+	locate   LocateFunc
+	visited  map[string]bool // canonical path -> fully resolved and appended
+	visiting map[string]bool // canonical path -> on the current descent (cycle guard)
+	packs    []*Rulepack
+	warnings []string
+}
+
+// NewResolver returns a Resolver that resolves installed-pack references
+// through locate.
+func NewResolver(locate LocateFunc) *Resolver {
+	return &Resolver{
+		locate:   locate,
+		visited:  map[string]bool{},
+		visiting: map[string]bool{},
+	}
+}
+
+// Add loads the rulepack at path, resolves its extends chain, and appends any
+// packs not already seen (bases first, the pack itself last). Failing to load
+// path itself is an error; a reference that cannot be resolved degrades to a
+// warning.
+func (r *Resolver) Add(path string) error {
+	key := canonicalPath(path)
+	if r.visited[key] {
+		return nil
+	}
+	pack, err := LoadFile(path)
+	if err != nil {
+		return err
+	}
+	r.resolve(pack, key)
+	return nil
+}
+
+// Packs returns the accumulated packs: deduplicated, every base before the
+// packs that extend it, roots in the order they were added.
+func (r *Resolver) Packs() []*Rulepack { return r.packs }
+
+// Warnings returns non-fatal issues met while resolving: missing or cyclic
+// extends references.
+func (r *Resolver) Warnings() []string { return r.warnings }
+
+func (r *Resolver) resolve(pack *Rulepack, key string) {
+	r.visiting[key] = true
+	for _, ref := range pack.Extends {
+		target, ok := r.target(pack, key, ref)
+		if !ok {
+			continue
+		}
+		tkey := canonicalPath(target)
+		if r.visited[tkey] {
+			continue
+		}
+		if r.visiting[tkey] {
+			r.warnf("%s: extends %q forms a cycle (skipped)", describePack(pack, key), ref)
+			continue
+		}
+		base, err := LoadFile(target)
+		if err != nil {
+			r.warnf("%s: extends %q: %v (skipped)", describePack(pack, key), ref, err)
+			continue
+		}
+		r.resolve(base, tkey)
+	}
+	delete(r.visiting, key)
+	r.visited[key] = true
+	r.packs = append(r.packs, pack)
+}
+
+// target resolves one extends reference to a file path. A reference containing
+// a path separator or ending in .yaml/.yml is a file path relative to the
+// referencing file; anything else is an installed pack name.
+func (r *Resolver) target(pack *Rulepack, key, ref string) (string, bool) {
+	if isPathRef(ref) {
+		if filepath.IsAbs(ref) {
+			return ref, true
+		}
+		return filepath.Join(filepath.Dir(key), ref), true
+	}
+	if ref == RecommendedName {
+		r.warnf("%s: extends %q is unnecessary — the recommended pack is always active (skipped)",
+			describePack(pack, key), ref)
+		return "", false
+	}
+	if r.locate != nil {
+		if p, ok := r.locate(ref); ok {
+			return p, true
+		}
+	}
+	r.warnf("%s: extends %q, which is not installed (run: leash add %s)", describePack(pack, key), ref, ref)
+	return "", false
+}
+
+func (r *Resolver) warnf(format string, args ...any) {
+	r.warnings = append(r.warnings, fmt.Sprintf(format, args...))
+}
+
+func isPathRef(ref string) bool {
+	return strings.ContainsAny(ref, `/\`) ||
+		strings.HasSuffix(ref, ".yaml") || strings.HasSuffix(ref, ".yml")
+}
+
+func canonicalPath(path string) string {
+	if abs, err := filepath.Abs(path); err == nil {
+		return abs
+	}
+	return filepath.Clean(path)
+}
+
+func describePack(pack *Rulepack, key string) string {
+	if pack.Name != "" {
+		return fmt.Sprintf("pack %q", pack.Name)
+	}
+	return key
+}

--- a/internal/policy/resolve_test.go
+++ b/internal/policy/resolve_test.go
@@ -1,0 +1,236 @@
+package policy
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writePack(t *testing.T, dir, file, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, file)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func packNames(packs []*Rulepack) []string {
+	names := make([]string, 0, len(packs))
+	for _, p := range packs {
+		names = append(names, p.Name)
+	}
+	return names
+}
+
+func wantOrder(t *testing.T, r *Resolver, want ...string) {
+	t.Helper()
+	got := packNames(r.Packs())
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("pack order = %v, want %v", got, want)
+	}
+}
+
+func TestResolverNoExtends(t *testing.T) {
+	dir := t.TempDir()
+	path := writePack(t, dir, "solo.yaml", "name: solo\n")
+	r := NewResolver(nil)
+	if err := r.Add(path); err != nil {
+		t.Fatal(err)
+	}
+	wantOrder(t, r, "solo")
+	if w := r.Warnings(); len(w) != 0 {
+		t.Fatalf("unexpected warnings: %v", w)
+	}
+}
+
+func TestResolverFileRefLayersBaseFirst(t *testing.T) {
+	dir := t.TempDir()
+	writePack(t, dir, "base.yaml", "name: base\n")
+	top := writePack(t, dir, "top.yaml", "name: top\nextends: [./base.yaml]\n")
+	r := NewResolver(nil)
+	if err := r.Add(top); err != nil {
+		t.Fatal(err)
+	}
+	wantOrder(t, r, "base", "top")
+}
+
+func TestResolverFileRefRelativeToReferencingFile(t *testing.T) {
+	dir := t.TempDir()
+	writePack(t, dir, "shared/base.yaml", "name: base\n")
+	top := writePack(t, dir, "nested/top.yaml", "name: top\nextends: [../shared/base.yaml]\n")
+	r := NewResolver(nil)
+	if err := r.Add(top); err != nil {
+		t.Fatal(err)
+	}
+	wantOrder(t, r, "base", "top")
+}
+
+func TestResolverInstalledNameRef(t *testing.T) {
+	dir := t.TempDir()
+	installed := writePack(t, dir, "team.yaml", "name: team\n")
+	top := writePack(t, dir, "top.yaml", "name: top\nextends: [team]\n")
+	locate := func(name string) (string, bool) {
+		if name == "team" {
+			return installed, true
+		}
+		return "", false
+	}
+	r := NewResolver(locate)
+	if err := r.Add(top); err != nil {
+		t.Fatal(err)
+	}
+	wantOrder(t, r, "team", "top")
+}
+
+func TestResolverMissingInstalledNameWarnsWithHint(t *testing.T) {
+	dir := t.TempDir()
+	top := writePack(t, dir, "top.yaml", "name: top\nextends: [ghost]\n")
+	r := NewResolver(nil)
+	if err := r.Add(top); err != nil {
+		t.Fatal(err)
+	}
+	wantOrder(t, r, "top") // the pack itself still loads
+	if len(r.Warnings()) != 1 || !strings.Contains(r.Warnings()[0], "leash add ghost") {
+		t.Fatalf("want a warning hinting `leash add ghost`, got %v", r.Warnings())
+	}
+}
+
+func TestResolverMissingFileRefWarns(t *testing.T) {
+	dir := t.TempDir()
+	top := writePack(t, dir, "top.yaml", "name: top\nextends: [./nope.yaml]\n")
+	r := NewResolver(nil)
+	if err := r.Add(top); err != nil {
+		t.Fatal(err)
+	}
+	wantOrder(t, r, "top")
+	if len(r.Warnings()) != 1 {
+		t.Fatalf("want one warning, got %v", r.Warnings())
+	}
+}
+
+func TestResolverChainOrdering(t *testing.T) {
+	dir := t.TempDir()
+	writePack(t, dir, "c.yaml", "name: c\n")
+	writePack(t, dir, "b.yaml", "name: b\nextends: [./c.yaml]\n")
+	a := writePack(t, dir, "a.yaml", "name: a\nextends: [./b.yaml]\n")
+	r := NewResolver(nil)
+	if err := r.Add(a); err != nil {
+		t.Fatal(err)
+	}
+	wantOrder(t, r, "c", "b", "a")
+}
+
+func TestResolverSharedBaseDedupedAcrossAdds(t *testing.T) {
+	dir := t.TempDir()
+	writePack(t, dir, "base.yaml", "name: base\n")
+	r1 := writePack(t, dir, "r1.yaml", "name: r1\nextends: [./base.yaml]\n")
+	r2 := writePack(t, dir, "r2.yaml", "name: r2\nextends: [./base.yaml]\n")
+	r := NewResolver(nil)
+	if err := r.Add(r1); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Add(r2); err != nil {
+		t.Fatal(err)
+	}
+	wantOrder(t, r, "base", "r1", "r2")
+}
+
+func TestResolverCycleSkippedNotFollowed(t *testing.T) {
+	dir := t.TempDir()
+	writePack(t, dir, "b.yaml", "name: b\nextends: [./a.yaml]\n")
+	a := writePack(t, dir, "a.yaml", "name: a\nextends: [./b.yaml]\n")
+	r := NewResolver(nil)
+	if err := r.Add(a); err != nil {
+		t.Fatal(err)
+	}
+	// Both packs still load; only the back-edge is dropped.
+	wantOrder(t, r, "b", "a")
+	if len(r.Warnings()) != 1 || !strings.Contains(r.Warnings()[0], "cycle") {
+		t.Fatalf("want one cycle warning, got %v", r.Warnings())
+	}
+}
+
+func TestResolverSelfExtendSkipped(t *testing.T) {
+	dir := t.TempDir()
+	a := writePack(t, dir, "a.yaml", "name: a\nextends: [./a.yaml]\n")
+	r := NewResolver(nil)
+	if err := r.Add(a); err != nil {
+		t.Fatal(err)
+	}
+	wantOrder(t, r, "a")
+	if len(r.Warnings()) != 1 || !strings.Contains(r.Warnings()[0], "cycle") {
+		t.Fatalf("want one cycle warning, got %v", r.Warnings())
+	}
+}
+
+func TestResolverRecommendedRefSkipped(t *testing.T) {
+	dir := t.TempDir()
+	top := writePack(t, dir, "top.yaml", "name: top\nextends: [recommended]\n")
+	r := NewResolver(nil)
+	if err := r.Add(top); err != nil {
+		t.Fatal(err)
+	}
+	wantOrder(t, r, "top")
+	if len(r.Warnings()) != 1 || !strings.Contains(r.Warnings()[0], "always active") {
+		t.Fatalf("want an always-active warning, got %v", r.Warnings())
+	}
+}
+
+func TestResolverDuplicateRootAddedOnce(t *testing.T) {
+	dir := t.TempDir()
+	a := writePack(t, dir, "a.yaml", "name: a\n")
+	r := NewResolver(nil)
+	if err := r.Add(a); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Add(a); err != nil {
+		t.Fatal(err)
+	}
+	wantOrder(t, r, "a")
+}
+
+func TestResolverRootLoadFailureIsAnError(t *testing.T) {
+	r := NewResolver(nil)
+	if err := r.Add(filepath.Join(t.TempDir(), "missing.yaml")); err == nil {
+		t.Fatal("want an error for an unloadable root pack")
+	}
+}
+
+// The point of the ordering: the extending pack's overrides retune what it
+// extends, because extended packs land earlier in the pool.
+func TestResolverExtendingPackWins(t *testing.T) {
+	dir := t.TempDir()
+	writePack(t, dir, "base.yaml", `name: base
+rules:
+  - id: base-rule
+    description: test
+    effect: deny
+    match:
+      regex: 'zzz-extends-marker'
+`)
+	top := writePack(t, dir, "top.yaml", `name: top
+extends: [./base.yaml]
+overrides:
+  base-rule: ask
+`)
+	r := NewResolver(nil)
+	if err := r.Add(top); err != nil {
+		t.Fatal(err)
+	}
+	e := NewEngine(r.Packs()...)
+	d := e.Evaluate(Action{Kind: ActionShell, Command: "echo zzz-extends-marker", Cwd: "/w"})
+	if d.Effect != EffectAsk {
+		t.Fatalf("Effect = %q, want ask (top pack's override must win over its base)", d.Effect)
+	}
+}
+
+func TestExtendsEmptyEntryRejected(t *testing.T) {
+	if _, err := Load(strings.NewReader("name: bad\nextends: ['  ']\n")); err == nil {
+		t.Fatal("want a validation error for an empty extends entry")
+	}
+}

--- a/internal/policy/rule.go
+++ b/internal/policy/rule.go
@@ -17,7 +17,12 @@ type Rule struct {
 
 	regex *regexp.Regexp // compiled form of Match.Regex
 	url   *regexp.Regexp // compiled form of Match.URLRegex
+	pack  string         // provenance: which pack supplied this rule (stamped by NewEngine, not YAML)
 }
+
+// Pack names the rulepack this rule came from. It is provenance stamped when
+// an engine pools the rule — pack authors cannot set it in YAML.
+func (r *Rule) Pack() string { return r.pack }
 
 // Match is the condition of a rule. An empty Match never matches (rules must be
 // specific); a non-empty Match requires all of its set conditions to hold.

--- a/internal/policy/rulepack.go
+++ b/internal/policy/rulepack.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -18,6 +19,10 @@ type Rulepack struct {
 	Name string `yaml:"name"`
 	// Default is the effect applied when no rule matches. Last pack to set it wins.
 	Default Effect `yaml:"default,omitempty"`
+	// Extends pulls other packs in below this one: each entry is an installed
+	// pack name or a file path relative to this file. A Resolver flattens the
+	// chain so this pack's rules, overrides, and default win.
+	Extends []string `yaml:"extends,omitempty"`
 	// Overrides retunes existing rules by id, changing only their effect
 	// (e.g. soften a recommended deny to ask). Applied across all packs once
 	// rules are pooled; later packs win.
@@ -55,6 +60,9 @@ func LoadFile(path string) (*Rulepack, error) {
 	return pack, nil
 }
 
+// RecommendedName is the name of the embedded, always-active pack.
+const RecommendedName = "recommended"
+
 // Recommended returns the rulepack shipped with Leash.
 func Recommended() *Rulepack {
 	f, err := builtinFS.Open("builtin/recommended.yaml")
@@ -73,6 +81,11 @@ func Recommended() *Rulepack {
 func (p *Rulepack) validate() error {
 	if p.Default != "" && !p.Default.Valid() {
 		return fmt.Errorf("rulepack %q has invalid default effect %q", p.Name, p.Default)
+	}
+	for _, ref := range p.Extends {
+		if strings.TrimSpace(ref) == "" {
+			return fmt.Errorf("rulepack %q has an empty extends entry", p.Name)
+		}
 	}
 	for id, eff := range p.Overrides {
 		if !eff.Valid() {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1,0 +1,205 @@
+// Package registry reads shareable rulepacks from a static index — a plain
+// index.yaml plus pack files, hosted anywhere. The default registry is the
+// registry/ directory of the Leash repo, read live off main. Fetching happens
+// only in explicit commands (leash add / search / update); the evaluation
+// path never imports this package, so no agent tool call can ever wait on the
+// network.
+package registry
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// DefaultIndexURL is the built-in registry: the index file in the Leash repo.
+const DefaultIndexURL = "https://raw.githubusercontent.com/hoophq/leash/main/registry/index.yaml"
+
+// Schema is the index schema this build understands.
+const Schema = 1
+
+// maxFetchBytes caps a fetched index or pack. Rulepacks are small YAML files;
+// anything bigger is a misbehaving server, not a pack.
+const maxFetchBytes = 5 << 20
+
+// Entry describes one pack published in a registry index.
+type Entry struct {
+	Name        string   `yaml:"name"`
+	Description string   `yaml:"description,omitempty"`
+	Version     string   `yaml:"version"`
+	SHA256      string   `yaml:"sha256"`
+	Path        string   `yaml:"path"` // relative to the index's own location
+	Tags        []string `yaml:"tags,omitempty"`
+	Maintainer  string   `yaml:"maintainer,omitempty"`
+}
+
+// Index is a registry index: the list of published packs.
+type Index struct {
+	Schema int     `yaml:"schema"`
+	Packs  []Entry `yaml:"packs"`
+}
+
+// Client reads one registry, identified by the location of its index file —
+// an http(s) URL or a local path.
+type Client struct{ location string }
+
+// NewClient returns a client for the index at location; empty means the
+// built-in registry.
+func NewClient(location string) *Client {
+	if location == "" {
+		location = DefaultIndexURL
+	}
+	return &Client{location: location}
+}
+
+// Location returns the index location this client reads.
+func (c *Client) Location() string { return c.location }
+
+// Index fetches and parses the registry index.
+func (c *Client) Index() (*Index, error) {
+	data, err := fetch(c.location)
+	if err != nil {
+		return nil, err
+	}
+	var idx Index
+	if err := yaml.Unmarshal(data, &idx); err != nil {
+		return nil, fmt.Errorf("parse registry index: %w", err)
+	}
+	if idx.Schema > Schema {
+		return nil, fmt.Errorf("registry index schema %d is newer than this leash understands — upgrade leash", idx.Schema)
+	}
+	return &idx, nil
+}
+
+// FetchPack downloads the pack e points at and verifies its sha256 against
+// the checksum the index declares before returning the bytes. Nothing is
+// written to disk.
+func (c *Client) FetchPack(e Entry) ([]byte, error) {
+	loc, err := resolveRef(c.location, e.Path)
+	if err != nil {
+		return nil, err
+	}
+	data, err := fetch(loc)
+	if err != nil {
+		return nil, err
+	}
+	sum := sha256.Sum256(data)
+	if got := hex.EncodeToString(sum[:]); !strings.EqualFold(got, e.SHA256) {
+		return nil, fmt.Errorf("pack %q failed checksum verification: index declares sha256 %s, got %s — refusing to install", e.Name, e.SHA256, got)
+	}
+	return data, nil
+}
+
+// Find returns the entry named name.
+func (idx *Index) Find(name string) (Entry, bool) {
+	for _, e := range idx.Packs {
+		if e.Name == name {
+			return e, true
+		}
+	}
+	return Entry{}, false
+}
+
+// Search returns entries whose name, description, or tags contain query
+// (case-insensitive), sorted by name. An empty query returns everything.
+func (idx *Index) Search(query string) []Entry {
+	q := strings.ToLower(strings.TrimSpace(query))
+	var out []Entry
+	for _, e := range idx.Packs {
+		if q == "" || matchesQuery(e, q) {
+			out = append(out, e)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+func matchesQuery(e Entry, q string) bool {
+	if strings.Contains(strings.ToLower(e.Name), q) ||
+		strings.Contains(strings.ToLower(e.Description), q) {
+		return true
+	}
+	for _, tag := range e.Tags {
+		if strings.Contains(strings.ToLower(tag), q) {
+			return true
+		}
+	}
+	return false
+}
+
+func isRemote(location string) bool {
+	u, err := url.Parse(location)
+	return err == nil && (u.Scheme == "http" || u.Scheme == "https")
+}
+
+// fetch reads location — over HTTP(S) for a URL, from disk for a path.
+func fetch(location string) ([]byte, error) {
+	if !isRemote(location) {
+		return os.ReadFile(location)
+	}
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Get(location)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch %s: %s", location, resp.Status)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxFetchBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxFetchBytes {
+		return nil, fmt.Errorf("fetch %s: response exceeds %d bytes", location, maxFetchBytes)
+	}
+	return data, nil
+}
+
+// resolveRef joins a pack reference against the index location: URL-relative
+// for a remote index, path-relative for a local one. A ref that could escape
+// the index's location — its own scheme or host, an absolute path, or a ..
+// segment — is rejected, so an index entry can only ever point beside itself.
+func resolveRef(base, ref string) (string, error) {
+	if err := validatePackRef(ref); err != nil {
+		return "", err
+	}
+	if isRemote(base) {
+		bu, err := url.Parse(base)
+		if err != nil {
+			return "", err
+		}
+		ru, err := url.Parse(ref)
+		if err != nil {
+			return "", fmt.Errorf("pack path %q: %w", ref, err)
+		}
+		return bu.ResolveReference(ru).String(), nil
+	}
+	return filepath.Join(filepath.Dir(base), ref), nil
+}
+
+func validatePackRef(ref string) error {
+	u, err := url.Parse(ref)
+	if err != nil {
+		return fmt.Errorf("pack path %q: %w", ref, err)
+	}
+	if u.IsAbs() || u.Host != "" || strings.HasPrefix(ref, "/") || filepath.IsAbs(ref) {
+		return fmt.Errorf("pack path %q must be relative to the index", ref)
+	}
+	if slices.Contains(strings.Split(path.Clean(ref), "/"), "..") {
+		return fmt.Errorf("pack path %q must not escape the index directory", ref)
+	}
+	return nil
+}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -1,0 +1,230 @@
+package registry
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const testPack = `name: sample
+rules:
+  - id: sample-rule
+    description: test
+    effect: ask
+    match:
+      regex: 'zzz-sample'
+`
+
+func sha256hex(data string) string {
+	sum := sha256.Sum256([]byte(data))
+	return hex.EncodeToString(sum[:])
+}
+
+func testIndexYAML(sum string) string {
+	return fmt.Sprintf(`schema: 1
+packs:
+  - name: sample
+    description: A sample pack for infra guardrails
+    version: "1.0.0"
+    sha256: %s
+    path: packs/sample.yaml
+    tags: [infra, sample]
+`, sum)
+}
+
+// writeLocalRegistry lays out index.yaml + packs/sample.yaml in a temp dir and
+// returns the index path.
+func writeLocalRegistry(t *testing.T, indexYAML string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "packs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "packs", "sample.yaml"), []byte(testPack), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	index := filepath.Join(dir, "index.yaml")
+	if err := os.WriteFile(index, []byte(indexYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return index
+}
+
+func TestIndexAndFetchPackFromLocalDir(t *testing.T) {
+	index := writeLocalRegistry(t, testIndexYAML(sha256hex(testPack)))
+	c := NewClient(index)
+
+	idx, err := c.Index()
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry, ok := idx.Find("sample")
+	if !ok {
+		t.Fatal("sample pack not found in index")
+	}
+	data, err := c.FetchPack(entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != testPack {
+		t.Fatalf("fetched pack differs from published pack")
+	}
+}
+
+func TestIndexAndFetchPackOverHTTP(t *testing.T) {
+	var packRequests []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/registry/index.yaml", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, testIndexYAML(sha256hex(testPack)))
+	})
+	mux.HandleFunc("/registry/packs/sample.yaml", func(w http.ResponseWriter, r *http.Request) {
+		packRequests = append(packRequests, r.URL.Path)
+		fmt.Fprint(w, testPack)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := NewClient(srv.URL + "/registry/index.yaml")
+	idx, err := c.Index()
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry, _ := idx.Find("sample")
+	data, err := c.FetchPack(entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != testPack {
+		t.Fatal("fetched pack differs from published pack")
+	}
+	// The relative path in the index must resolve against the index URL.
+	if len(packRequests) != 1 || packRequests[0] != "/registry/packs/sample.yaml" {
+		t.Fatalf("pack fetched from %v, want /registry/packs/sample.yaml", packRequests)
+	}
+}
+
+func TestFetchPackRejectsChecksumMismatch(t *testing.T) {
+	index := writeLocalRegistry(t, testIndexYAML(sha256hex("something else entirely")))
+	c := NewClient(index)
+	idx, err := c.Index()
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry, _ := idx.Find("sample")
+	data, err := c.FetchPack(entry)
+	if err == nil || !strings.Contains(err.Error(), "checksum") {
+		t.Fatalf("want a checksum error, got data=%v err=%v", data != nil, err)
+	}
+	if data != nil {
+		t.Fatal("no bytes may be returned on checksum mismatch")
+	}
+}
+
+func TestIndexSchemaTooNew(t *testing.T) {
+	index := writeLocalRegistry(t, "schema: 99\npacks: []\n")
+	if _, err := NewClient(index).Index(); err == nil || !strings.Contains(err.Error(), "upgrade leash") {
+		t.Fatalf("want an upgrade-leash error for a newer schema, got %v", err)
+	}
+}
+
+func TestIndexInvalidYAML(t *testing.T) {
+	index := writeLocalRegistry(t, "packs: [not: valid: yaml\n")
+	if _, err := NewClient(index).Index(); err == nil {
+		t.Fatal("want a parse error for invalid index YAML")
+	}
+}
+
+func TestIndexNotFoundOverHTTP(t *testing.T) {
+	srv := httptest.NewServer(http.NotFoundHandler())
+	defer srv.Close()
+	if _, err := NewClient(srv.URL + "/index.yaml").Index(); err == nil {
+		t.Fatal("want an error for a 404 index")
+	}
+}
+
+func TestDefaultLocation(t *testing.T) {
+	if got := NewClient("").Location(); got != DefaultIndexURL {
+		t.Fatalf("Location = %q, want the default index URL", got)
+	}
+}
+
+func TestSearch(t *testing.T) {
+	idx := &Index{Packs: []Entry{
+		{Name: "terraform-safety", Description: "Guard terraform operations", Tags: []string{"iac"}},
+		{Name: "prod-db-guard", Description: "Ask before production databases", Tags: []string{"database"}},
+		{Name: "k8s-safety", Description: "Kubernetes guardrails", Tags: []string{"kubernetes"}},
+	}}
+
+	cases := []struct {
+		query string
+		want  []string
+	}{
+		{"", []string{"k8s-safety", "prod-db-guard", "terraform-safety"}}, // all, sorted
+		{"terraform", []string{"terraform-safety"}},                       // name match
+		{"PRODUCTION", []string{"prod-db-guard"}},                         // description, case-insensitive
+		{"kubernetes", []string{"k8s-safety"}},                            // tag match
+		{"nothing-matches-this", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.query, func(t *testing.T) {
+			var got []string
+			for _, e := range idx.Search(tc.query) {
+				got = append(got, e.Name)
+			}
+			if strings.Join(got, ",") != strings.Join(tc.want, ",") {
+				t.Fatalf("Search(%q) = %v, want %v", tc.query, got, tc.want)
+			}
+		})
+	}
+}
+
+// An index entry's path may only point beside the index — never to another
+// host, an absolute location, or out of the index's directory.
+func TestResolveRefStaysBesideIndex(t *testing.T) {
+	cases := []struct {
+		ref string
+		ok  bool
+	}{
+		{"packs/x.yaml", true},
+		{"./packs/x.yaml", true},
+		{"https://attacker.example/x.yaml", false},
+		{"//attacker.example/x.yaml", false},
+		{"/etc/x.yaml", false},
+		{"packs/../../escape.yaml", false},
+	}
+	bases := []string{"https://example.com/registry/index.yaml", "/srv/registry/index.yaml"}
+	for _, base := range bases {
+		for _, tc := range cases {
+			t.Run(base+" -> "+tc.ref, func(t *testing.T) {
+				_, err := resolveRef(base, tc.ref)
+				if ok := err == nil; ok != tc.ok {
+					t.Fatalf("resolveRef(%q, %q) err = %v, want ok=%v", base, tc.ref, err, tc.ok)
+				}
+			})
+		}
+	}
+}
+
+func TestIsRemote(t *testing.T) {
+	cases := []struct {
+		location string
+		want     bool
+	}{
+		{"https://example.com/index.yaml", true},
+		{"http://localhost:8080/index.yaml", true},
+		{"/abs/path/index.yaml", false},
+		{"./relative/index.yaml", false},
+		{"registry/index.yaml", false},
+	}
+	for _, tc := range cases {
+		if got := isRemote(tc.location); got != tc.want {
+			t.Errorf("isRemote(%q) = %v, want %v", tc.location, got, tc.want)
+		}
+	}
+}

--- a/internal/registry/seed_test.go
+++ b/internal/registry/seed_test.go
@@ -1,0 +1,158 @@
+package registry
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	"github.com/hoophq/leash/internal/policy"
+)
+
+// seedIndex loads the registry shipped in this repo. It is the same path
+// leash add takes, so a stale sha256 in registry/index.yaml fails here first,
+// not on a user's machine.
+func seedIndex(t *testing.T) (*Client, *Index) {
+	t.Helper()
+	c := NewClient(filepath.Join("..", "..", "registry", "index.yaml"))
+	idx, err := c.Index()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(idx.Packs) == 0 {
+		t.Fatal("the shipped registry has no packs")
+	}
+	return c, idx
+}
+
+func TestSeedRegistryIntegrity(t *testing.T) {
+	c, idx := seedIndex(t)
+
+	packs := []*policy.Rulepack{policy.Recommended()}
+	for _, e := range idx.Packs {
+		data, err := c.FetchPack(e)
+		if err != nil {
+			t.Fatalf("pack %q: %v\n(after editing a seed pack, recompute its sha256 in registry/index.yaml)", e.Name, err)
+		}
+		pack, err := policy.Load(bytes.NewReader(data))
+		if err != nil {
+			t.Fatalf("pack %q does not load: %v", e.Name, err)
+		}
+		if pack.Name != e.Name {
+			t.Errorf("pack file name %q != index name %q", pack.Name, e.Name)
+		}
+		if e.Version == "" || e.Description == "" {
+			t.Errorf("pack %q: index entry needs a version and description", e.Name)
+		}
+		packs = append(packs, pack)
+	}
+
+	// All seed packs must coexist with recommended and each other: no
+	// duplicate rule ids, no override warnings.
+	engine := policy.NewEngine(packs...)
+	if ws := engine.Warnings(); len(ws) != 0 {
+		t.Fatalf("engine warnings with all seed packs loaded: %v", ws)
+	}
+}
+
+// The seed packs follow the same discipline as the recommended pack: every
+// catch pinned alongside the everyday commands that must stay silent.
+func TestSeedRegistryDecisions(t *testing.T) {
+	c, idx := seedIndex(t)
+	packs := []*policy.Rulepack{policy.Recommended()}
+	for _, e := range idx.Packs {
+		data, err := c.FetchPack(e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pack, err := policy.Load(bytes.NewReader(data))
+		if err != nil {
+			t.Fatal(err)
+		}
+		packs = append(packs, pack)
+	}
+	engine := policy.NewEngine(packs...)
+
+	cases := []struct {
+		command string
+		want    policy.Effect
+	}{
+		// terraform-safety: catches.
+		{"terraform destroy", policy.EffectDeny},
+		{"tofu destroy -auto-approve", policy.EffectDeny},
+		{"terraform -chdir=envs/prod destroy", policy.EffectDeny},
+		{"terraform apply -destroy", policy.EffectDeny},
+		{"terraform apply -auto-approve", policy.EffectAsk},
+		{"terraform state rm aws_instance.web", policy.EffectAsk},
+		{"terraform force-unlock 1234", policy.EffectAsk},
+		// terraform-safety: everyday operations stay silent.
+		{"terraform plan -destroy", policy.EffectAllow},
+		{"terraform plan", policy.EffectAllow},
+		{"terraform apply", policy.EffectAllow},
+		{"terraform state list", policy.EffectAllow},
+		{"terraform init", policy.EffectAllow},
+
+		// prod-db-guard: catches.
+		{"psql postgres://prod-db.internal/app", policy.EffectAsk},
+		{"mysql -h production.example.com", policy.EffectAsk},
+		{`psql -c "DROP TABLE users"`, policy.EffectAsk},
+		{`mysql -e "truncate table sessions"`, policy.EffectAsk},
+		{`mongosh --eval "db.dropDatabase()"`, policy.EffectAsk},
+		// prod-db-guard: local development stays silent.
+		{"psql -h localhost dev_db", policy.EffectAllow},
+		{`psql -c "SELECT * FROM users"`, policy.EffectAllow},
+		{"mysql -h 127.0.0.1 test", policy.EffectAllow},
+		{`mongosh --eval "db.stats()"`, policy.EffectAllow},
+
+		// k8s-safety: catches.
+		{"kubectl delete namespace staging", policy.EffectAsk},
+		{"kubectl delete ns foo", policy.EffectAsk},
+		{"kubectl delete pods --all", policy.EffectAsk},
+		{"kubectl delete deployments -A", policy.EffectAsk},
+		{"kubectl drain node-1", policy.EffectAsk},
+		{"kubectl cordon node-1", policy.EffectAsk},
+		{"kubectl config use-context prod-us-east", policy.EffectWarn},
+		// k8s-safety: everyday operations stay silent.
+		{"kubectl get pods -A", policy.EffectAllow},
+		{"kubectl delete pod crashed-pod-abc", policy.EffectAllow},
+		{"kubectl apply -f deploy.yaml", policy.EffectAllow},
+		{"kubectl uncordon node-1", policy.EffectAllow},
+		{"kubectl config use-context dev", policy.EffectAllow},
+		{"kubectl config use-context product-catalog-dev", policy.EffectAllow},
+		{"kubectl logs -f api-5d9", policy.EffectAllow},
+	}
+	for _, tc := range cases {
+		t.Run(tc.command, func(t *testing.T) {
+			d := engine.Evaluate(policy.Action{Kind: policy.ActionShell, Command: tc.command, Cwd: "/Users/dev/project"})
+			if d.Effect != tc.want {
+				rule := ""
+				if d.Rule != nil {
+					rule = d.Rule.ID
+				}
+				t.Fatalf("Effect = %q (rule %q), want %q", d.Effect, rule, tc.want)
+			}
+		})
+	}
+
+	// terraform-safety's file rule: state files ask, ordinary files pass.
+	writeCases := []struct {
+		path string
+		want policy.Effect
+	}{
+		{"infra/terraform.tfstate", policy.EffectAsk},
+		{"infra/terraform.tfstate.backup", policy.EffectAsk},
+		{"main.tf", policy.EffectAllow},
+		{"docs/notes.md", policy.EffectAllow},
+	}
+	for _, tc := range writeCases {
+		t.Run("write "+tc.path, func(t *testing.T) {
+			d := engine.Evaluate(policy.Action{Kind: policy.ActionFileWrite, Path: tc.path, Cwd: "/Users/dev/project"})
+			if d.Effect != tc.want {
+				rule := ""
+				if d.Rule != nil {
+					rule = d.Rule.ID
+				}
+				t.Fatalf("Effect = %q (rule %q), want %q", d.Effect, rule, tc.want)
+			}
+		})
+	}
+}

--- a/internal/store/lockfile.go
+++ b/internal/store/lockfile.go
@@ -1,0 +1,69 @@
+package store
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// LockSchema is the packs.lock.json schema this build writes.
+const LockSchema = 1
+
+// LockEntry records where an installed pack came from.
+type LockEntry struct {
+	Version     string    `json:"version"`
+	SHA256      string    `json:"sha256"`
+	Source      string    `json:"source"` // the registry index it was installed from
+	InstalledAt time.Time `json:"installed_at"`
+}
+
+// NewLockEntry stamps a lock entry for a pack installed right now.
+func NewLockEntry(version, sha256, source string) LockEntry {
+	return LockEntry{Version: version, SHA256: sha256, Source: source, InstalledAt: time.Now().UTC()}
+}
+
+// Lockfile is the metadata sidecar for installed packs. It never decides what
+// is active — the packs directory does — it only remembers versions and
+// sources for `leash update` and `leash search`.
+type Lockfile struct {
+	Schema int                  `json:"schema"`
+	Packs  map[string]LockEntry `json:"packs"`
+}
+
+func (s *Store) lockPath() string { return filepath.Join(s.dir, "packs.lock.json") }
+
+// Lockfile reads the store's lockfile; a missing file is an empty lockfile.
+func (s *Store) Lockfile() (*Lockfile, error) {
+	lf := &Lockfile{Schema: LockSchema, Packs: map[string]LockEntry{}}
+	data, err := os.ReadFile(s.lockPath())
+	if errors.Is(err, os.ErrNotExist) {
+		return lf, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(data, lf); err != nil {
+		return nil, fmt.Errorf("%s is not valid JSON: %w", s.lockPath(), err)
+	}
+	if lf.Packs == nil {
+		lf.Packs = map[string]LockEntry{}
+	}
+	return lf, nil
+}
+
+// SaveLockfile writes the lockfile, creating the store directory if needed.
+func (s *Store) SaveLockfile(lf *Lockfile) error {
+	lf.Schema = LockSchema
+	if err := os.MkdirAll(s.dir, 0o755); err != nil {
+		return err
+	}
+	out, err := json.MarshalIndent(lf, "", "  ")
+	if err != nil {
+		return err
+	}
+	out = append(out, '\n')
+	return os.WriteFile(s.lockPath(), out, 0o644)
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,0 +1,143 @@
+// Package store manages Leash's user-level state directory (~/.leash): the
+// rulepacks installed from a registry, and the lockfile recording where each
+// came from. The packs directory is the source of truth for what is active;
+// the lockfile is metadata for update/search, so a damaged lockfile can never
+// disable protection.
+package store
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/hoophq/leash/internal/policy"
+)
+
+// Store is a Leash state directory.
+type Store struct{ dir string }
+
+// Open returns a Store rooted at dir. The directory need not exist yet.
+func Open(dir string) *Store { return &Store{dir: dir} }
+
+// DefaultDir returns the default state directory, ~/.leash.
+func DefaultDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("locate home directory: %w", err)
+	}
+	return filepath.Join(home, ".leash"), nil
+}
+
+// packExts are the extensions a pack file may carry inside the store; Install
+// always writes the first.
+var packExts = []string{".yaml", ".yml"}
+
+func (s *Store) packsDir() string { return filepath.Join(s.dir, "packs") }
+
+// PackPath returns where the pack named name is (or would be) installed.
+func (s *Store) PackPath(name string) string {
+	return filepath.Join(s.packsDir(), name+".yaml")
+}
+
+// List returns the names of installed packs, sorted. A store that has never
+// been used is not an error — it is just empty.
+func (s *Store) List() ([]string, error) {
+	entries, err := os.ReadDir(s.packsDir())
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if name, ok := trimPackExt(e.Name()); ok {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// trimPackExt strips a recognised pack extension, reporting whether the file
+// name carried one.
+func trimPackExt(name string) (string, bool) {
+	for _, ext := range packExts {
+		if trimmed, ok := strings.CutSuffix(name, ext); ok {
+			return trimmed, true
+		}
+	}
+	return "", false
+}
+
+// Locate resolves an installed pack name to its file path. It satisfies
+// policy.LocateFunc.
+func (s *Store) Locate(name string) (string, bool) {
+	if !ValidName(name) {
+		return "", false
+	}
+	for _, ext := range packExts {
+		p := filepath.Join(s.packsDir(), name+ext)
+		if info, err := os.Stat(p); err == nil && !info.IsDir() {
+			return p, true
+		}
+	}
+	return "", false
+}
+
+// Has reports whether a pack named name is installed.
+func (s *Store) Has(name string) bool {
+	_, ok := s.Locate(name)
+	return ok
+}
+
+// Install validates data as a rulepack and writes it as name, returning the
+// parsed pack. Nothing is written when validation fails.
+func (s *Store) Install(name string, data []byte) (*policy.Rulepack, error) {
+	if !ValidName(name) {
+		return nil, fmt.Errorf("invalid pack name %q", name)
+	}
+	pack, err := policy.Load(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("pack %q: %w", name, err)
+	}
+	if err := os.MkdirAll(s.packsDir(), 0o755); err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(s.PackPath(name), data, 0o644); err != nil {
+		return nil, err
+	}
+	return pack, nil
+}
+
+// Remove deletes the installed pack named name.
+func (s *Store) Remove(name string) error {
+	path, ok := s.Locate(name)
+	if !ok {
+		return fmt.Errorf("pack %q is not installed", name)
+	}
+	return os.Remove(path)
+}
+
+// ValidName reports whether name is usable as an installed pack name: a bare
+// name with no path separators, traversal, or extension — it must name a file
+// directly under the store's packs directory.
+func ValidName(name string) bool {
+	if name == "" || name == "." || name == ".." {
+		return false
+	}
+	if strings.ContainsAny(name, `/\`) {
+		return false
+	}
+	if _, ok := trimPackExt(name); ok {
+		return false
+	}
+	return name == filepath.Base(name)
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,0 +1,139 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const validPack = `name: sample
+rules:
+  - id: sample-rule
+    description: test
+    effect: ask
+    match:
+      regex: 'zzz-sample'
+`
+
+func TestInstallLoadRoundTrip(t *testing.T) {
+	s := Open(t.TempDir())
+	pack, err := s.Install("sample", []byte(validPack))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pack.Name != "sample" || len(pack.Rules) != 1 {
+		t.Fatalf("parsed pack = %q with %d rules, want sample with 1", pack.Name, len(pack.Rules))
+	}
+	if !s.Has("sample") {
+		t.Fatal("installed pack not found by Has")
+	}
+	path, ok := s.Locate("sample")
+	if !ok || path != s.PackPath("sample") {
+		t.Fatalf("Locate = %q, %v; want %q", path, ok, s.PackPath("sample"))
+	}
+}
+
+func TestInstallRejectsInvalidPackAndWritesNothing(t *testing.T) {
+	s := Open(t.TempDir())
+	if _, err := s.Install("bad", []byte("rules:\n  - id: x\n    effect: nope\n")); err == nil {
+		t.Fatal("want an error for an invalid rulepack")
+	}
+	if s.Has("bad") {
+		t.Fatal("invalid pack must not be written to disk")
+	}
+}
+
+func TestInstallRejectsUnsafeNames(t *testing.T) {
+	s := Open(t.TempDir())
+	for _, name := range []string{"", ".", "..", "../evil", "a/b", `a\b`, "x.yaml", "x.yml"} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := s.Install(name, []byte(validPack)); err == nil {
+				t.Fatalf("want an error for unsafe pack name %q", name)
+			}
+		})
+	}
+}
+
+func TestListEmptyStoreIsNotAnError(t *testing.T) {
+	s := Open(filepath.Join(t.TempDir(), "never-created"))
+	names, err := s.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(names) != 0 {
+		t.Fatalf("want no packs, got %v", names)
+	}
+}
+
+func TestListSortedNames(t *testing.T) {
+	s := Open(t.TempDir())
+	for _, name := range []string{"zeta", "alpha", "mid"} {
+		if _, err := s.Install(name, []byte(validPack)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	names, err := s.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(names, ",") != "alpha,mid,zeta" {
+		t.Fatalf("List = %v, want sorted [alpha mid zeta]", names)
+	}
+}
+
+func TestRemove(t *testing.T) {
+	s := Open(t.TempDir())
+	if _, err := s.Install("sample", []byte(validPack)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Remove("sample"); err != nil {
+		t.Fatal(err)
+	}
+	if s.Has("sample") {
+		t.Fatal("pack still present after Remove")
+	}
+	if err := s.Remove("sample"); err == nil {
+		t.Fatal("want an error removing a pack that is not installed")
+	}
+}
+
+func TestLockfileRoundTrip(t *testing.T) {
+	s := Open(t.TempDir())
+
+	lf, err := s.Lockfile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lf.Packs) != 0 {
+		t.Fatalf("fresh lockfile should be empty, got %v", lf.Packs)
+	}
+
+	lf.Packs["sample"] = LockEntry{Version: "1.0.0", SHA256: "abc", Source: "https://example.com/index.yaml"}
+	if err := s.SaveLockfile(lf); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.Lockfile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Schema != LockSchema {
+		t.Fatalf("schema = %d, want %d", got.Schema, LockSchema)
+	}
+	entry, ok := got.Packs["sample"]
+	if !ok || entry.Version != "1.0.0" || entry.SHA256 != "abc" {
+		t.Fatalf("lock entry = %+v, %v", entry, ok)
+	}
+}
+
+func TestLockfileInvalidJSONIsAnError(t *testing.T) {
+	dir := t.TempDir()
+	s := Open(dir)
+	if err := os.WriteFile(filepath.Join(dir, "packs.lock.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Lockfile(); err == nil {
+		t.Fatal("want an error for a corrupt lockfile")
+	}
+}

--- a/registry/index.yaml
+++ b/registry/index.yaml
@@ -1,0 +1,32 @@
+# The Leash rulepack registry.
+#
+# `leash search` and `leash add` read this file live off the main branch —
+# publishing a pack is a PR that adds a file under packs/ and an entry here.
+# See docs/registry.md for the authoring walkthrough (including how to compute
+# the sha256). CI verifies every entry's checksum and that every pack loads.
+schema: 1
+
+packs:
+  - name: terraform-safety
+    description: Block terraform destroy; confirm state mutations and unreviewed applies
+    version: "1.0.0"
+    sha256: b87e4b899a574be6a3818acd96ebcaac7a6a155eb3068d224cef7df0336f057a
+    path: packs/terraform-safety.yaml
+    tags: [terraform, tofu, infra, iac]
+    maintainer: hoophq
+
+  - name: prod-db-guard
+    description: Confirm production database sessions and destructive SQL from CLI clients
+    version: "1.0.0"
+    sha256: 284d89b86e36417940b71ad6ab9ed8da62bde554d2af6ffa7ecd410dd09372f7
+    path: packs/prod-db-guard.yaml
+    tags: [database, postgres, mysql, mongodb, production]
+    maintainer: hoophq
+
+  - name: k8s-safety
+    description: Confirm namespace deletes, --all sweeps, and node drains; warn on prod contexts
+    version: "1.0.0"
+    sha256: 27afb468f7fc160fcb20d337146ff991eef55953e381b70a0af3604d27388de6
+    path: packs/k8s-safety.yaml
+    tags: [kubernetes, kubectl, infra]
+    maintainer: hoophq

--- a/registry/packs/k8s-safety.yaml
+++ b/registry/packs/k8s-safety.yaml
@@ -1,0 +1,57 @@
+# k8s-safety — guardrails for kubectl.
+#
+# Asks before cluster-shaped blast radius: namespace deletion, --all deletes,
+# node drains. Warns on a switch to a production context. Routine gets/applies
+# stay silent.
+#
+# Install:  leash add k8s-safety
+name: k8s-safety
+
+rules:
+  - id: k8s-delete-namespace
+    description: Deleting a Kubernetes namespace removes everything in it
+    severity: high
+    effect: ask
+    message: >-
+      Deleting a namespace removes every resource inside it. Confirm the
+      namespace and the cluster context before continuing.
+    match:
+      shell:
+        command_in: [kubectl]
+      regex: '\bdelete\s+(ns|namespaces?)\b'
+
+  - id: k8s-delete-all
+    description: kubectl delete with --all/-A sweeps whole resource sets
+    severity: high
+    effect: ask
+    message: >-
+      This delete uses --all or -A and can sweep far more than one resource.
+      Confirm the scope before continuing.
+    match:
+      shell:
+        command_in: [kubectl]
+      regex: '\bdelete\b.*(\s--all\b|\s--all-namespaces\b|\s-A\b)'
+
+  - id: k8s-node-drain
+    description: Draining or cordoning a node evicts its workloads
+    severity: medium
+    effect: ask
+    message: >-
+      Draining or cordoning a node evicts or blocks workloads on it. Confirm
+      this is intended.
+    match:
+      shell:
+        command_in: [kubectl]
+      regex: '\b(drain|cordon)\b'
+
+  - id: k8s-context-production
+    description: Switching kubectl to a production context
+    severity: low
+    effect: warn
+    message: >-
+      kubectl is switching to a production-looking context — subsequent
+      commands will hit that cluster.
+    match:
+      shell:
+        command_in: [kubectl]
+      regex: '(?i)use-context\s+\S*\b(prod|production)\b'

--- a/registry/packs/prod-db-guard.yaml
+++ b/registry/packs/prod-db-guard.yaml
@@ -1,0 +1,43 @@
+# prod-db-guard — a pause before an agent touches a database.
+#
+# Asks before production-flavored database sessions and destructive SQL from
+# the common CLI clients. Everyday local development queries stay silent.
+#
+# Install:  leash add prod-db-guard
+name: prod-db-guard
+
+rules:
+  - id: prod-db-session
+    description: Opening a database session against something named prod
+    severity: high
+    effect: ask
+    message: >-
+      This database command targets something named prod/production. Confirm
+      the agent should be talking to that database.
+    match:
+      shell:
+        command_in: [psql, mysql, mongosh, mongo, redis-cli]
+      regex: '(?i)\b(prod|production)\b'
+
+  - id: prod-db-destructive-sql
+    description: DROP or TRUNCATE issued through a database CLI
+    severity: high
+    effect: ask
+    message: >-
+      This runs destructive SQL (DROP/TRUNCATE) through a database client.
+      Confirm the target database and statement before continuing.
+    match:
+      shell:
+        command_in: [psql, mysql]
+      regex: '(?i)\b(drop\s+(database|schema|table)\b|truncate(\s+table)?\s+\S)'
+
+  - id: prod-db-mongo-drop
+    description: Dropping a MongoDB database from the shell
+    severity: high
+    effect: ask
+    message: >-
+      This drops a MongoDB database. Confirm the target before continuing.
+    match:
+      shell:
+        command_in: [mongosh, mongo]
+      regex: '(?i)dropdatabase\s*\('

--- a/registry/packs/terraform-safety.yaml
+++ b/registry/packs/terraform-safety.yaml
@@ -1,0 +1,71 @@
+# terraform-safety — guardrails for Terraform / OpenTofu.
+#
+# Blocks `terraform destroy` outright and asks before state mutations and
+# unreviewed applies. `terraform plan -destroy` (a preview) stays untouched.
+#
+# Install:  leash add terraform-safety
+# Soften:   overrides: { terraform-destroy: ask }  in your .leash.yaml
+name: terraform-safety
+
+rules:
+  - id: terraform-destroy
+    description: terraform destroy tears down live infrastructure
+    severity: critical
+    effect: deny
+    message: >-
+      terraform destroy tears down live infrastructure and is blocked by the
+      terraform-safety pack. If you really mean it, run it yourself — or
+      soften this rule with an override (terraform-destroy: ask).
+    match:
+      shell:
+        command_in: [terraform, tofu]
+      regex: '\b(terraform|tofu)\b(\s+-\S+)*\s+(destroy\b|apply\b.*\s-+destroy\b)'
+
+  - id: terraform-apply-auto-approve
+    description: terraform apply -auto-approve skips plan review
+    severity: high
+    effect: ask
+    message: >-
+      This apply skips the plan review (-auto-approve). Confirm the change is
+      what you expect before letting it run.
+    match:
+      shell:
+        command_in: [terraform, tofu]
+      regex: '\b(terraform|tofu)\b.*\bapply\b.*\s-+auto-approve\b'
+
+  - id: terraform-state-mutation
+    description: terraform state rm/mv/push rewrites the state file
+    severity: high
+    effect: ask
+    message: >-
+      This command rewrites Terraform state (state rm/mv/push). A mistake here
+      orphans or duplicates real resources. Confirm before continuing.
+    match:
+      shell:
+        command_in: [terraform, tofu]
+      regex: '\b(terraform|tofu)\b.*\bstate\s+(rm|mv|push)\b'
+
+  - id: terraform-force-unlock
+    description: terraform force-unlock releases another run's state lock
+    severity: medium
+    effect: ask
+    message: >-
+      force-unlock releases a state lock that may be held by a live run.
+      Confirm nobody else is applying right now.
+    match:
+      shell:
+        command_in: [terraform, tofu]
+      regex: '\b(terraform|tofu)\b.*\bforce-unlock\b'
+
+  - id: terraform-state-file-write
+    description: Editing a Terraform state file directly
+    severity: high
+    effect: ask
+    message: >-
+      This edit targets a Terraform state file. Hand-edited state is a classic
+      way to lose track of real infrastructure — confirm this is intended.
+    match:
+      tool: [file_write]
+      path_glob:
+        - "**/*.tfstate"
+        - "**/*.tfstate.backup"


### PR DESCRIPTION
Implements [ATR-9](https://linear.app/hoophq/issue/ATR-9/implement-shareable-rulepack-registry): rulepacks become a shareable, installable artifact — the ESLint-config / Semgrep-registry pattern, sized for leash.

## What this ships

**Four commands** (all accept `--registry <url or path>` for self-hosting):

```console
$ leash search terraform          # discover
$ leash add terraform-safety      # sha256-verified install, live on the next tool call
$ leash update                    # refresh installed packs
$ leash remove terraform-safety
```

**A static registry in-repo** — `registry/index.yaml` + `registry/packs/*.yaml`, read raw off `main`. Publishing a pack is a PR; a seed test re-verifies every checksum and loads every pack in CI, so a stale sha256 fails the build, not someone's install. Three seeded packs: `terraform-safety`, `prod-db-guard`, `k8s-safety`.

**`extends:` composition** — any pack (including `./.leash.yaml`) layers other packs beneath itself by installed name or relative path, with cycle skipping, diamond dedup, and a `run: leash add <name>` hint when a target is missing. A committed `.leash.yaml` with `extends:` pins a team baseline.

## Design points

- **Layering**: `recommended < installed (a-z) < ./.leash.yaml < --rules`; most-severe-effect resolution unchanged.
- **No network on the eval path, by construction** — only the explicit commands import `internal/registry`; `buildEngine` reads local files only, and `internal/policy` stays agent- and store-neutral (extends resolution takes an injected locator).
- **Degrade, don't die**: a corrupt installed pack or `.leash.yaml` is skipped with a stderr warning while everything else keeps protecting (previously one bad file silenced even the recommended pack in the hook path). The explicit `--rules` file stays a hard error.
- **Integrity**: sha256 verified against the index before any byte reaches disk; `~/.leash/packs.lock.json` records version/checksum/source. `update` refuses to let one registry replace a same-named pack installed from another (dependency-confusion guard), and index `path:` entries cannot point off-host or escape the index directory.
- **Provenance**: `check` names the pack behind a decision (`rule: k8s-delete-namespace (high) · from k8s-safety`), and cross-pack rule-id collisions warn.
- Zero new dependencies — stdlib `net/http` + `crypto/sha256`.

## Docs

New `docs/registry.md` (consume / author / publish / self-host, plus an honest section on what the checksum does and doesn't protect against), new sections in `docs/cli.md` and `docs/rules.md`, package rows + a third extension point in `docs/architecture.md`, README roadmap box checked.

## Testing

`go test ./...` — 60+ new table-driven tests across policy (resolver ordering/cycles/dedup), store (traversal-safe names, lockfile), registry (httptest + local-dir fetch, checksum rejection, path confinement), CLI (per-source degradation, layering order, cross-registry update refusal), and the seed packs (every catch pinned next to the everyday commands that must stay silent — `terraform plan -destroy`, `kubectl uncordon`, local psql all stay ALLOW).

Smoke-tested end-to-end with a sandboxed `$HOME`: search → add → deny in `leash check` and through the real Claude Code hook JSON → cross-registry update refusal.

Note: `leash add` against the default URL starts working the moment this lands on `main` (the index is read from there); until then `--registry ./registry/index.yaml` exercises the identical path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELGtA6PwYn95WAzwzmwXV3