### PR TITLE
Make Leash visible in chat: session banner + decision notices

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,10 @@ central audit, and approval workflows out of scope.
   semantic facts (recursive-delete + target class, force-push, history-rewrite,
   net→shell pipe). **This is the differentiator** — see Conventions.
 - `internal/adapter/<agent>/` — translate one agent's tool call ⇄ neutral `Action`.
-  `claudecode` (Claude Code PreToolUse) is the first adapter.
+  `claudecode` (Claude Code PreToolUse + the SessionStart banner) is the first
+  adapter. Decisions and chat notices ride the same JSON envelope; an explicit
+  "allow" decision is never emitted (it would bypass the user's own permission
+  settings).
 - `internal/store/` — the user-level state dir (`~/.leash`): packs installed via
   `leash add` (the packs dir is the source of truth) + `packs.lock.json` metadata.
 - `internal/registry/` — fetch + sha256-verify packs from a static index

--- a/README.md
+++ b/README.md
@@ -94,11 +94,14 @@ npm install -g @hoophq/leash
 ## Quickstart — Claude Code
 
 ```bash
-leash init --global   # add the PreToolUse hook to .claude/settings.json, for every project
+leash init --global   # add the Leash hooks to .claude/settings.json, for every project
 ```
 
-Start a Claude Code session and Leash is live. Ask the agent for something
-reckless — it gets stopped, or asked to confirm.
+Start a Claude Code session and Leash is live — a banner in the chat confirms
+it (`🐕 Leash is guarding this session…`). Ask the agent for something
+reckless — it gets stopped, or asked to confirm, with a `🐕` notice in the chat
+saying which rule fired. Want a notice for allowed calls too? `leash init
+--verbose`.
 
 ```bash
 claude

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,15 +9,26 @@ flag ([rulepack reference](rules.md)).
 ## `leash init`
 
 Wire Leash into Claude Code: it adds a `PreToolUse` hook to the settings so
-every tool call is inspected before it runs.
+every tool call is inspected before it runs, and a `SessionStart` hook that
+shows a banner in the chat when a session begins — proof Leash is active,
+with the pack and rule counts.
 
 ```bash
 leash init            # project — ./.claude/settings.json
 leash init --global   # global  — ~/.claude/settings.json
+leash init --verbose  # also show a 🐕 chat notice for *allowed* tool calls
 ```
 
-Idempotent and non-destructive: it preserves existing settings and won't add the
-hook twice. Restart Claude Code (or start a new session) to activate it.
+Deny, ask, and warn decisions always show a `🐕` notice in the chat naming the
+rule that fired; `--verbose` adds one for allowed calls too (noisy, but useful
+for a demo or for building trust). Re-run `init` without the flag to switch
+back — it always converges the hook commands, which is also how a stale binary
+path gets healed after an upgrade. Flags init doesn't manage (say, a
+hand-added `--rules`) survive that convergence.
+
+Idempotent and non-destructive: it preserves existing settings (including a
+matcher you've customized) and won't add the hooks twice. Restart Claude Code
+(or start a new session) to activate them.
 
 ## `leash search`
 
@@ -111,8 +122,19 @@ echo '{"cwd":".","tool_name":"Bash","tool_input":{"command":"rm -rf ~"}}' \
   | leash hook claude-code
 ```
 
-It always exits 0 and **fails open**: if the input can't be understood, the tool
-call proceeds as if Leash weren't there.
+Deny/ask/warn responses carry a `systemMessage` so the decision is visible in
+the chat. With `--verbose`, allowed calls get a notice too — but never an
+explicit allow decision, so your own permission settings still apply.
+
+`leash hook claude-code session-start` is the `SessionStart` entrypoint: it
+prints the "guarding this session" banner (wired in by `leash init` as well).
+If an installed pack or `.leash.yaml` fails to load, the banner says so —
+`⚠️ 1 rulepack failed to load` — instead of silently showing a lower count;
+run any leash command in a terminal to see the load warnings.
+
+Every variant always exits 0 and **fails open**: if the input can't be
+understood or the rules can't load, the tool call proceeds as if Leash weren't
+there — and the session banner says so instead of pretending you're covered.
 
 ## `leash version`
 

--- a/internal/adapter/claudecode/claudecode.go
+++ b/internal/adapter/claudecode/claudecode.go
@@ -96,9 +96,13 @@ func writeContent(tool string, ti toolInput) string {
 	return ""
 }
 
-// hookOutput is the PreToolUse response envelope.
+// hookOutput is the hook response envelope. SystemMessage is a line Claude
+// Code shows to the user in the chat; HookSpecificOutput carries the
+// permission decision and is omitted entirely when Leash has no opinion
+// (warn feedback, verbose allow feedback, the session banner).
 type hookOutput struct {
-	HookSpecificOutput hookSpecificOutput `json:"hookSpecificOutput"`
+	SystemMessage      string              `json:"systemMessage,omitempty"`
+	HookSpecificOutput *hookSpecificOutput `json:"hookSpecificOutput,omitempty"`
 }
 
 type hookSpecificOutput struct {
@@ -107,44 +111,118 @@ type hookSpecificOutput struct {
 	PermissionDecisionReason string `json:"permissionDecisionReason,omitempty"`
 }
 
-// WriteDecision emits the Claude Code response for a decision on w, and returns
-// any human-readable note that should be surfaced on stderr (used for "warn",
-// which allows the action but informs the user).
+// WriteDecision emits the Claude Code response for a decision on w.
 //
-//   - deny  -> permissionDecision "deny"  (blocks the tool call)
-//   - ask   -> permissionDecision "ask"   (forces a user confirmation prompt)
-//   - warn  -> no decision emitted; note returned for stderr; action proceeds
-//   - allow -> nothing emitted; normal permission flow continues
-func WriteDecision(w io.Writer, d policy.Decision) (note string, err error) {
-	reason := decisionReason(d)
+//   - deny  -> permissionDecision "deny"  (blocks the tool call) + chat notice
+//   - ask   -> permissionDecision "ask"   (forces a user confirmation prompt) + chat notice
+//   - warn  -> no decision emitted; chat notice only; action proceeds
+//   - allow -> nothing emitted so the user's own permission flow is untouched;
+//     with verbose, a chat notice (still no decision) confirms Leash looked
+//
+// Emitting an explicit "allow" decision would auto-approve the call and bypass
+// the user's permission settings, so Leash never does — even in verbose mode.
+func WriteDecision(w io.Writer, d policy.Decision, verbose bool) error {
 	switch d.Effect {
 	case policy.EffectDeny:
-		return "", emit(w, "deny", reason)
+		return emit(w, hookOutput{
+			SystemMessage:      systemMessage("blocked this", d),
+			HookSpecificOutput: preToolUse("deny", decisionReason(d)),
+		})
 	case policy.EffectAsk:
-		return "", emit(w, "ask", reason)
+		return emit(w, hookOutput{
+			SystemMessage:      systemMessage("is asking first", d),
+			HookSpecificOutput: preToolUse("ask", decisionReason(d)),
+		})
 	case policy.EffectWarn:
-		return reason, nil
+		return emit(w, hookOutput{SystemMessage: systemMessage("flagged this", d)})
 	default:
-		// allow: stay silent so we don't override the user's own settings.
-		return "", nil
+		if !verbose {
+			return nil
+		}
+		return emit(w, hookOutput{SystemMessage: systemMessage("allowed this", d)})
 	}
 }
 
-func emit(w io.Writer, decision, reason string) error {
-	out := hookOutput{HookSpecificOutput: hookSpecificOutput{
+// WriteSessionStart emits the SessionStart response: a banner telling the user
+// Leash is active — and, when ambient rulepacks failed to load, that the
+// session runs with less than the configured protection. It carries no
+// permission decision and adds nothing to the model's context (plain stdout on
+// SessionStart would).
+func WriteSessionStart(w io.Writer, version string, packs, rules, failed int) error {
+	name := "Leash"
+	if version != "" {
+		if version[0] >= '0' && version[0] <= '9' {
+			version = "v" + version
+		}
+		name += " " + version
+	}
+	msg := fmt.Sprintf("🐕 %s is guarding this session (%s, %s)",
+		name, plural(packs, "pack"), plural(rules, "rule"))
+	if failed > 0 {
+		msg += fmt.Sprintf(" — ⚠️ %s failed to load", plural(failed, "rulepack"))
+	}
+	return emit(w, hookOutput{SystemMessage: msg})
+}
+
+// WriteSessionStartDegraded emits the SessionStart banner for the case where
+// the rules could not be loaded: the hook fails open, so the honest message is
+// that this session is not being screened.
+func WriteSessionStartDegraded(w io.Writer) error {
+	return emit(w, hookOutput{
+		SystemMessage: "🐕 Leash could not load its rules — tool calls in this session are NOT being screened (see stderr in the transcript)",
+	})
+}
+
+func emit(w io.Writer, out hookOutput) error {
+	return json.NewEncoder(w).Encode(out)
+}
+
+func preToolUse(decision, reason string) *hookSpecificOutput {
+	return &hookSpecificOutput{
 		HookEventName:            "PreToolUse",
 		PermissionDecision:       decision,
 		PermissionDecisionReason: reason,
-	}}
-	return json.NewEncoder(w).Encode(out)
+	}
+}
+
+// systemMessage builds the one-line chat notice for a decision, e.g.
+// "🐕 Leash is asking first: Force-push detected. … (rule: git-force-push)".
+func systemMessage(verb string, d policy.Decision) string {
+	// Rule messages may be multi-line YAML blocks; a chat notice is one line.
+	reason := strings.Join(strings.Fields(decisionReason(d)), " ")
+
+	var b strings.Builder
+	b.WriteString("🐕 ")
+	switch {
+	case reason == "":
+		b.WriteString("Leash ")
+		b.WriteString(verb)
+	// Many rule messages already speak as Leash ("Leash blocked a recursive
+	// delete …"); prefixing the verb again would stutter.
+	case len(reason) >= 6 && strings.EqualFold(reason[:6], "leash "):
+		b.WriteString(reason)
+	default:
+		b.WriteString("Leash ")
+		b.WriteString(verb)
+		b.WriteString(": ")
+		b.WriteString(reason)
+	}
+	if d.Rule != nil && d.Rule.ID != "" {
+		fmt.Fprintf(&b, " (rule: %s)", d.Rule.ID)
+	}
+	return b.String()
+}
+
+func plural(n int, noun string) string {
+	if n == 1 {
+		return fmt.Sprintf("1 %s", noun)
+	}
+	return fmt.Sprintf("%d %ss", n, noun)
 }
 
 func decisionReason(d policy.Decision) string {
 	if d.Rule == nil {
 		return ""
 	}
-	if d.Rule.Message != "" {
-		return d.Rule.Message
-	}
-	return d.Rule.Description
+	return d.Rule.Text()
 }

--- a/internal/adapter/claudecode/claudecode_test.go
+++ b/internal/adapter/claudecode/claudecode_test.go
@@ -1,6 +1,8 @@
 package claudecode
 
 import (
+	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -64,5 +66,226 @@ func TestParseActionContent(t *testing.T) {
 				t.Errorf("Command = %q, want %q", a.Command, tc.wantCommand)
 			}
 		})
+	}
+}
+
+// decode parses a hook response for assertions. Absent keys stay absent — the
+// tests below rely on that to prove no permission decision was emitted.
+func decode(t *testing.T, raw string) map[string]any {
+	t.Helper()
+	var out map[string]any
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, raw)
+	}
+	return out
+}
+
+func TestWriteDecision(t *testing.T) {
+	rule := &policy.Rule{ID: "rm-recursive-home", Message: "Recursive delete of your home directory"}
+
+	cases := []struct {
+		name    string
+		d       policy.Decision
+		verbose bool
+
+		wantEmpty    bool   // nothing at all on stdout
+		wantDecision string // hookSpecificOutput.permissionDecision ("" = key must be absent)
+		wantReason   string
+		wantMsgParts []string // substrings the systemMessage must contain
+	}{
+		{
+			name:         "deny blocks and announces",
+			d:            policy.Decision{Effect: policy.EffectDeny, Rule: rule},
+			wantDecision: "deny",
+			wantReason:   "Recursive delete of your home directory",
+			wantMsgParts: []string{"Leash blocked this", "Recursive delete", "(rule: rm-recursive-home)"},
+		},
+		{
+			name:         "ask prompts and announces",
+			d:            policy.Decision{Effect: policy.EffectAsk, Rule: rule},
+			wantDecision: "ask",
+			wantReason:   "Recursive delete of your home directory",
+			wantMsgParts: []string{"Leash is asking first"},
+		},
+		{
+			name:         "warn announces without a decision so the call proceeds",
+			d:            policy.Decision{Effect: policy.EffectWarn, Rule: rule},
+			wantMsgParts: []string{"Leash flagged this", "(rule: rm-recursive-home)"},
+		},
+		{
+			name:      "allow stays silent by default",
+			d:         policy.Decision{Effect: policy.EffectAllow},
+			wantEmpty: true,
+		},
+		{
+			name:         "verbose allow announces without a decision",
+			d:            policy.Decision{Effect: policy.EffectAllow},
+			verbose:      true,
+			wantMsgParts: []string{"Leash allowed this"},
+		},
+		{
+			name:         "deny from a pack default has no rule to cite",
+			d:            policy.Decision{Effect: policy.EffectDeny},
+			wantDecision: "deny",
+			wantMsgParts: []string{"Leash blocked this"},
+		},
+		{
+			name: "multi-line rule message collapses to one chat line",
+			d: policy.Decision{Effect: policy.EffectDeny, Rule: &policy.Rule{
+				ID:      "multi",
+				Message: "line one\n  line two",
+			}},
+			wantDecision: "deny",
+			wantReason:   "line one\n  line two",
+			wantMsgParts: []string{"line one line two"},
+		},
+		{
+			name: "a reason that already speaks as Leash is not double-branded",
+			d: policy.Decision{Effect: policy.EffectDeny, Rule: &policy.Rule{
+				ID:      "destructive-delete-sensitive",
+				Message: "Leash blocked a recursive delete aimed at a sensitive location.",
+			}},
+			wantDecision: "deny",
+			wantReason:   "Leash blocked a recursive delete aimed at a sensitive location.",
+			wantMsgParts: []string{"🐕 Leash blocked a recursive delete"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := WriteDecision(&buf, tc.d, tc.verbose); err != nil {
+				t.Fatalf("WriteDecision: %v", err)
+			}
+
+			if tc.wantEmpty {
+				if buf.Len() != 0 {
+					t.Fatalf("want no output, got %s", buf.String())
+				}
+				return
+			}
+
+			out := decode(t, buf.String())
+
+			msg, _ := out["systemMessage"].(string)
+			for _, part := range tc.wantMsgParts {
+				if !strings.Contains(msg, part) {
+					t.Errorf("systemMessage = %q, want it to contain %q", msg, part)
+				}
+			}
+			if strings.Contains(msg, "\n") {
+				t.Errorf("systemMessage must be a single line, got %q", msg)
+			}
+			if n := strings.Count(msg, "Leash"); n != 1 {
+				t.Errorf("systemMessage should name Leash exactly once, got %d in %q", n, msg)
+			}
+
+			hso, hasHSO := out["hookSpecificOutput"].(map[string]any)
+			if tc.wantDecision == "" {
+				// The load-bearing guard: no permission decision may leak. An
+				// explicit "allow" would bypass the user's own permission
+				// settings; an empty one is protocol garbage.
+				if hasHSO {
+					t.Fatalf("hookSpecificOutput must be absent, got %v", out["hookSpecificOutput"])
+				}
+				if strings.Contains(buf.String(), "permissionDecision") {
+					t.Fatalf("output must not mention permissionDecision: %s", buf.String())
+				}
+				return
+			}
+			if !hasHSO {
+				t.Fatalf("missing hookSpecificOutput in %s", buf.String())
+			}
+			if got := hso["permissionDecision"]; got != tc.wantDecision {
+				t.Errorf("permissionDecision = %v, want %q", got, tc.wantDecision)
+			}
+			if got, _ := hso["permissionDecisionReason"].(string); got != tc.wantReason {
+				t.Errorf("permissionDecisionReason = %q, want %q", got, tc.wantReason)
+			}
+			if got := hso["hookEventName"]; got != "PreToolUse" {
+				t.Errorf("hookEventName = %v, want PreToolUse", got)
+			}
+		})
+	}
+}
+
+func TestWriteSessionStart(t *testing.T) {
+	cases := []struct {
+		name    string
+		version string
+		packs   int
+		rules   int
+		failed  int
+		want    []string
+	}{
+		{
+			name:    "release version gets a v prefix",
+			version: "0.0.4", packs: 3, rules: 42,
+			want: []string{"Leash v0.0.4", "3 packs", "42 rules", "guarding this session"},
+		},
+		{
+			name:    "git-describe version is kept as-is",
+			version: "v0.0.4-2-gabc1234", packs: 2, rules: 40,
+			want: []string{"Leash v0.0.4-2-gabc1234"},
+		},
+		{
+			name:    "dev build and singular counts",
+			version: "dev", packs: 1, rules: 1,
+			want: []string{"Leash dev", "1 pack,", "1 rule)"},
+		},
+		{
+			name:  "no version at all",
+			packs: 1, rules: 34,
+			want: []string{"🐕 Leash is guarding this session"},
+		},
+		{
+			name:    "a failed ambient pack is called out",
+			version: "0.0.4", packs: 1, rules: 19, failed: 1,
+			want: []string{"⚠️ 1 rulepack failed to load"},
+		},
+		{
+			name:    "several failed packs pluralize",
+			version: "0.0.4", packs: 1, rules: 19, failed: 2,
+			want: []string{"2 rulepacks failed to load"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := WriteSessionStart(&buf, tc.version, tc.packs, tc.rules, tc.failed); err != nil {
+				t.Fatalf("WriteSessionStart: %v", err)
+			}
+			out := decode(t, buf.String())
+			msg, _ := out["systemMessage"].(string)
+			for _, part := range tc.want {
+				if !strings.Contains(msg, part) {
+					t.Errorf("systemMessage = %q, want it to contain %q", msg, part)
+				}
+			}
+			// A clean load must not hedge the banner.
+			if tc.failed == 0 && strings.Contains(msg, "failed to load") {
+				t.Errorf("clean banner mentions failures: %q", msg)
+			}
+			// A banner must never carry a permission decision.
+			if _, ok := out["hookSpecificOutput"]; ok {
+				t.Fatalf("banner must not include hookSpecificOutput: %s", buf.String())
+			}
+		})
+	}
+}
+
+func TestWriteSessionStartDegraded(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteSessionStartDegraded(&buf); err != nil {
+		t.Fatalf("WriteSessionStartDegraded: %v", err)
+	}
+	out := decode(t, buf.String())
+	msg, _ := out["systemMessage"].(string)
+	if !strings.Contains(msg, "NOT being screened") {
+		t.Errorf("degraded banner must say the session is unscreened, got %q", msg)
+	}
+	if _, ok := out["hookSpecificOutput"]; ok {
+		t.Fatalf("degraded banner must not include hookSpecificOutput: %s", buf.String())
 	}
 }

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -29,7 +29,7 @@ func newCheckCommand() *cobra.Command {
 			"  leash check --url https://evil.example/payload",
 		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			engine, err := buildEngine()
+			engine, _, err := buildEngine()
 			if err != nil {
 				return fail(cmd, err)
 			}
@@ -126,10 +126,7 @@ func printDecision(cmd *cobra.Command, a policy.Action, d policy.Decision) {
 }
 
 func ruleText(r *policy.Rule) string {
-	if r.Message != "" {
-		return collapse(r.Message)
-	}
-	return collapse(r.Description)
+	return collapse(r.Text())
 }
 
 func collapse(s string) string {

--- a/internal/cli/hook.go
+++ b/internal/cli/hook.go
@@ -2,28 +2,32 @@ package cli
 
 import (
 	"fmt"
-	"os"
+	"io"
 
 	"github.com/hoophq/leash/internal/adapter/claudecode"
 	"github.com/spf13/cobra"
 )
 
-func newHookCommand() *cobra.Command {
+func newHookCommand(version string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "hook",
 		Short: "Run as an agent hook (reads a tool call on stdin)",
 	}
-	cmd.AddCommand(newClaudeCodeHookCommand())
+	cmd.AddCommand(newClaudeCodeHookCommand(version))
 	return cmd
 }
 
-func newClaudeCodeHookCommand() *cobra.Command {
-	return &cobra.Command{
+func newClaudeCodeHookCommand(version string) *cobra.Command {
+	var verbose bool
+
+	cmd := &cobra.Command{
 		Use:   "claude-code",
 		Short: "Claude Code PreToolUse hook entrypoint",
 		Long: "Reads a Claude Code PreToolUse payload on stdin and writes a permission\n" +
 			"decision on stdout. Wire it up with `leash init`, or manually as a\n" +
 			"PreToolUse hook running `leash hook claude-code`.\n\n" +
+			"Deny/ask/warn decisions include a chat notice (systemMessage) so the\n" +
+			"user sees Leash act; with --verbose, allowed calls get a notice too.\n\n" +
 			"This command fails open: if anything goes wrong, the tool call is\n" +
 			"allowed so the agent is never bricked by Leash.",
 		Args: cobra.NoArgs,
@@ -31,36 +35,69 @@ func newClaudeCodeHookCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runClaudeCodeHook()
+			return runClaudeCodeHook(cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr(), verbose)
+		},
+	}
+	cmd.Flags().BoolVar(&verbose, "verbose", false,
+		"also show a chat notice for allowed tool calls (deny/ask/warn always show one)")
+	cmd.AddCommand(newSessionStartHookCommand(version))
+	return cmd
+}
+
+func newSessionStartHookCommand(version string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "session-start",
+		Short: "Claude Code SessionStart hook entrypoint (prints the session banner)",
+		Long: "Writes a SessionStart response whose systemMessage tells the user this\n" +
+			"session is guarded by Leash, with the active pack and rule counts.\n" +
+			"`leash init` wires it in alongside the PreToolUse hook.",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runSessionStartHook(cmd.OutOrStdout(), cmd.ErrOrStderr(), version)
 		},
 	}
 }
 
 // runClaudeCodeHook always returns nil (exit 0). It communicates decisions
-// through the JSON protocol on stdout, never through the exit code, and it
-// fails open on any internal error.
-func runClaudeCodeHook() error {
-	engine, err := buildEngine()
+// through the JSON protocol on out, never through the exit code, and it fails
+// open on any internal error.
+func runClaudeCodeHook(in io.Reader, out, errw io.Writer, verbose bool) error {
+	engine, _, err := buildEngine()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "leash: failed to load rules, allowing: %v\n", err)
+		fmt.Fprintf(errw, "leash: failed to load rules, allowing: %v\n", err)
 		return nil
 	}
 
-	action, err := claudecode.ParseAction(os.Stdin)
+	action, err := claudecode.ParseAction(in)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "leash: could not read tool call, allowing: %v\n", err)
+		fmt.Fprintf(errw, "leash: could not read tool call, allowing: %v\n", err)
 		return nil
 	}
 
 	decision := engine.Evaluate(action)
 
-	note, err := claudecode.WriteDecision(os.Stdout, decision)
+	if err := claudecode.WriteDecision(out, decision, verbose); err != nil {
+		fmt.Fprintf(errw, "leash: could not write decision, allowing: %v\n", err)
+	}
+	return nil
+}
+
+// runSessionStartHook always returns nil (exit 0): a banner must never block a
+// session from starting. It deliberately does not read stdin — blocking on an
+// agent that keeps the pipe open would do exactly that.
+func runSessionStartHook(out, errw io.Writer, version string) error {
+	engine, failed, err := buildEngine()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "leash: could not write decision, allowing: %v\n", err)
+		fmt.Fprintf(errw, "leash: failed to load rules: %v\n", err)
+		if err := claudecode.WriteSessionStartDegraded(out); err != nil {
+			fmt.Fprintf(errw, "leash: could not write session banner: %v\n", err)
+		}
 		return nil
 	}
-	if note != "" {
-		fmt.Fprintf(os.Stderr, "leash: %s\n", note)
+	if err := claudecode.WriteSessionStart(out, version, engine.PackCount(), engine.RuleCount(), failed); err != nil {
+		fmt.Fprintf(errw, "leash: could not write session banner: %v\n", err)
 	}
 	return nil
 }

--- a/internal/cli/hook_test.go
+++ b/internal/cli/hook_test.go
@@ -1,0 +1,116 @@
+package cli
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// isolateHome points HOME at an empty temp dir and moves into another, so the
+// developer's real ~/.leash and any project .leash.yaml never leak into the
+// engine under test. Returns the fake home.
+func isolateHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	chdirEmpty(t)
+	return home
+}
+
+// runLeash executes the real root command — flag parsing, subcommand dispatch,
+// stdin/stdout plumbing — and returns stdout.
+func runLeash(t *testing.T, stdin string, args ...string) string {
+	t.Helper()
+	root := NewRootCommand("1.2.3")
+	root.SetIn(strings.NewReader(stdin))
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(io.Discard)
+	root.SetArgs(args)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("leash %s: %v", strings.Join(args, " "), err)
+	}
+	return out.String()
+}
+
+func TestHookClaudeCodeDeny(t *testing.T) {
+	isolateHome(t)
+	out := runLeash(t, `{"cwd":".","tool_name":"Bash","tool_input":{"command":"rm -rf ~"}}`,
+		"hook", "claude-code")
+	for _, want := range []string{`"permissionDecision":"deny"`, `"systemMessage"`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %s:\n%s", want, out)
+		}
+	}
+}
+
+func TestHookClaudeCodeAllowIsSilent(t *testing.T) {
+	isolateHome(t)
+	out := runLeash(t, `{"cwd":".","tool_name":"Bash","tool_input":{"command":"ls -la"}}`,
+		"hook", "claude-code")
+	if out != "" {
+		t.Fatalf("an allowed call must produce no output, got:\n%s", out)
+	}
+}
+
+func TestHookClaudeCodeVerboseAllow(t *testing.T) {
+	isolateHome(t)
+	out := runLeash(t, `{"cwd":".","tool_name":"Bash","tool_input":{"command":"ls -la"}}`,
+		"hook", "claude-code", "--verbose")
+	if !strings.Contains(out, "Leash allowed this") {
+		t.Errorf("verbose allow missing the notice:\n%s", out)
+	}
+	// The bypass guard, end to end: verbose feedback must never carry a
+	// permission decision.
+	if strings.Contains(out, "permissionDecision") {
+		t.Fatalf("verbose allow must not emit a permission decision:\n%s", out)
+	}
+}
+
+func TestHookClaudeCodeFailsOpenOnGarbage(t *testing.T) {
+	isolateHome(t)
+	out := runLeash(t, "definitely not json", "hook", "claude-code")
+	if out != "" {
+		t.Fatalf("unparseable input must produce no output (fail open), got:\n%s", out)
+	}
+}
+
+func TestHookSessionStartBanner(t *testing.T) {
+	isolateHome(t)
+	out := runLeash(t, "", "hook", "claude-code", "session-start")
+	for _, want := range []string{"Leash v1.2.3 is guarding this session", "(1 pack,"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("banner missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "failed to load") {
+		t.Errorf("clean banner mentions failures:\n%s", out)
+	}
+	if strings.Contains(out, "hookSpecificOutput") {
+		t.Fatalf("banner must not carry a permission decision:\n%s", out)
+	}
+}
+
+func TestHookSessionStartReportsFailedPack(t *testing.T) {
+	home := isolateHome(t)
+	packs := filepath.Join(home, ".leash", "packs")
+	if err := os.MkdirAll(packs, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(packs, "broken.yaml"),
+		[]byte("rules:\n  - id: x\n    effect: nope\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out := runLeash(t, "", "hook", "claude-code", "session-start")
+	if !strings.Contains(out, "1 rulepack failed to load") {
+		t.Errorf("banner does not report the broken pack:\n%s", out)
+	}
+	// The recommended pack still protects underneath.
+	if !strings.Contains(out, "(1 pack,") {
+		t.Errorf("banner should still count the recommended pack:\n%s", out)
+	}
+}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -15,41 +16,53 @@ const hookCommand = "leash hook claude-code"
 // whose actions the engine actually evaluates.
 const toolMatcher = "Bash|Write|Edit|MultiEdit|NotebookEdit|WebFetch"
 
+// sessionStartMatcher fires the banner when a session begins or is cleared,
+// but not after every context compaction.
+const sessionStartMatcher = "startup|resume|clear"
+
 func newInitCommand() *cobra.Command {
-	var global bool
+	var (
+		global  bool
+		verbose bool
+	)
 
 	cmd := &cobra.Command{
 		Use:   "init",
-		Short: "Install the Leash hook into Claude Code settings",
-		Long: "Adds a PreToolUse hook to your Claude Code settings so Leash inspects\n" +
-			"each tool call. By default it writes the project settings\n" +
-			"(./.claude/settings.json); use --global for ~/.claude/settings.json.\n\n" +
-			"The change is idempotent and preserves any existing settings.",
+		Short: "Install the Leash hooks into Claude Code settings",
+		Long: "Adds two hooks to your Claude Code settings: a PreToolUse hook so Leash\n" +
+			"inspects each tool call, and a SessionStart hook that shows a banner\n" +
+			"confirming the session is guarded. By default it writes the project\n" +
+			"settings (./.claude/settings.json); use --global for ~/.claude/settings.json.\n\n" +
+			"The change is idempotent and preserves any existing settings. Re-running\n" +
+			"init always converges the hook commands, so it also heals a stale binary\n" +
+			"path and toggles --verbose on or off.",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			path, err := settingsPath(global)
 			if err != nil {
 				return fail(cmd, err)
 			}
-			result, err := installHook(path, hookInvocation())
+			result, err := installHooks(path, desiredHooks(verbose))
 			if err != nil {
 				return fail(cmd, err)
 			}
 			switch result {
 			case hookInstalled:
-				fmt.Fprintf(cmd.OutOrStdout(), "Installed Leash hook in %s\n", path)
-				fmt.Fprintf(cmd.OutOrStdout(), "Restart Claude Code (or start a new session) to activate it.\n")
+				fmt.Fprintf(cmd.OutOrStdout(), "Installed the Leash hooks in %s\n", path)
+				fmt.Fprintf(cmd.OutOrStdout(), "Restart Claude Code (or start a new session) to activate them.\n")
 			case hookUpdated:
-				fmt.Fprintf(cmd.OutOrStdout(), "Updated the Leash hook command in %s\n", path)
-				fmt.Fprintf(cmd.OutOrStdout(), "Restart Claude Code (or start a new session) to pick it up.\n")
+				fmt.Fprintf(cmd.OutOrStdout(), "Updated the Leash hook commands in %s\n", path)
+				fmt.Fprintf(cmd.OutOrStdout(), "Restart Claude Code (or start a new session) to pick them up.\n")
 			default:
-				fmt.Fprintf(cmd.OutOrStdout(), "Leash hook already present in %s\n", path)
+				fmt.Fprintf(cmd.OutOrStdout(), "Leash hooks already present in %s\n", path)
 			}
 			return nil
 		},
 	}
 
 	cmd.Flags().BoolVar(&global, "global", false, "install into ~/.claude/settings.json instead of the project")
+	cmd.Flags().BoolVar(&verbose, "verbose", false,
+		"show a chat notice for allowed tool calls too (re-run init without it to switch back)")
 	return cmd
 }
 
@@ -68,6 +81,28 @@ func settingsPath(global bool) (string, error) {
 	return filepath.Join(wd, ".claude", "settings.json"), nil
 }
 
+// hookSpec is one hook entry Leash wants present in the settings: the event to
+// hook, the matcher for new installs (an existing entry's matcher is never
+// touched — the user may have narrowed it), and the exact command to run.
+type hookSpec struct {
+	event   string
+	matcher string
+	command string
+}
+
+// desiredHooks returns the hook entries `leash init` converges the settings to.
+func desiredHooks(verbose bool) []hookSpec {
+	base := hookInvocation()
+	pre := base
+	if verbose {
+		pre += " --verbose"
+	}
+	return []hookSpec{
+		{event: "PreToolUse", matcher: toolMatcher, command: pre},
+		{event: "SessionStart", matcher: sessionStartMatcher, command: base + " session-start"},
+	}
+}
+
 // hookInvocation returns the command string Claude Code should run. It uses the
 // absolute path of the current binary so the hook works regardless of PATH, but
 // keeps symlinks unresolved: package managers point a stable symlink (e.g.
@@ -81,20 +116,23 @@ func hookInvocation() string {
 	return fmt.Sprintf("%s hook claude-code", exe)
 }
 
-// hookInstallResult describes what installHook changed.
+// hookInstallResult describes what installHooks changed. Higher values are
+// more newsworthy: an install (a hook that wasn't there before) outranks an
+// update (a command healed in place).
 type hookInstallResult int
 
 const (
 	hookUnchanged hookInstallResult = iota
-	hookInstalled
 	hookUpdated
+	hookInstalled
 )
 
-// installHook merges a PreToolUse hook into the settings file at path, creating
-// it if necessary. An existing leash hook whose command differs — e.g. a stale
-// binary path left by a previous install — is updated in place, so re-running
-// `leash init` always converges on a working hook.
-func installHook(path, command string) (hookInstallResult, error) {
+// installHooks merges the desired hook entries into the settings file at path,
+// creating it if necessary. An existing leash hook whose command differs —
+// e.g. a stale binary path left by a previous install, or a verbose toggle —
+// is updated in place, so re-running `leash init` always converges on working
+// hooks.
+func installHooks(path string, specs []hookSpec) (hookInstallResult, error) {
 	settings := map[string]any{}
 	if data, err := os.ReadFile(path); err == nil {
 		if len(data) > 0 {
@@ -107,39 +145,40 @@ func installHook(path, command string) (hookInstallResult, error) {
 	}
 
 	hooks := asMap(settings["hooks"])
-	preToolUse := asSlice(hooks["PreToolUse"])
 
 	result := hookUnchanged
-	for _, e := range preToolUse {
-		for _, h := range asSlice(asMap(e)["hooks"]) {
-			hm := asMap(h)
-			cmd, ok := hm["command"].(string)
-			if !ok || !containsHook(cmd) {
-				continue
+	for _, spec := range specs {
+		entries := asSlice(hooks[spec.event])
+		found := false
+		for _, e := range entries {
+			for _, h := range asSlice(asMap(e)["hooks"]) {
+				hm := asMap(h)
+				cmd, ok := hm["command"].(string)
+				if !ok || !containsHook(cmd) {
+					continue
+				}
+				found = true
+				if want := convergeCommand(cmd, spec.command); cmd != want {
+					hm["command"] = want
+					result = max(result, hookUpdated)
+				}
 			}
-			if cmd != command {
-				hm["command"] = command
-				return writeSettings(path, settings, hooks, preToolUse, hookUpdated)
-			}
-			result = hookInstalled // present and current
+		}
+		if !found {
+			entries = append(entries, map[string]any{
+				"matcher": spec.matcher,
+				"hooks": []any{
+					map[string]any{"type": "command", "command": spec.command},
+				},
+			})
+			hooks[spec.event] = entries
+			result = hookInstalled
 		}
 	}
-	if result == hookInstalled {
+
+	if result == hookUnchanged {
 		return hookUnchanged, nil
 	}
-
-	entry := map[string]any{
-		"matcher": toolMatcher,
-		"hooks": []any{
-			map[string]any{"type": "command", "command": command},
-		},
-	}
-	preToolUse = append(preToolUse, entry)
-	return writeSettings(path, settings, hooks, preToolUse, hookInstalled)
-}
-
-func writeSettings(path string, settings, hooks map[string]any, preToolUse []any, result hookInstallResult) (hookInstallResult, error) {
-	hooks["PreToolUse"] = preToolUse
 	settings["hooks"] = hooks
 
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -156,14 +195,50 @@ func writeSettings(path string, settings, hooks map[string]any, preToolUse []any
 	return result, nil
 }
 
-func containsHook(cmd string) bool {
-	return len(cmd) >= len(hookCommand) && (cmd == hookCommand ||
-		// match "<path>/leash hook claude-code" too
-		hasSuffix(cmd, hookCommand))
+// convergeCommand rewrites an existing Leash hook command to the desired
+// invocation while keeping any trailing tokens init does not manage (a
+// hand-added --rules, say): the user put them there, and dropping them would
+// silently weaken their setup. The tokens init owns — the session-start
+// subcommand and --verbose — are regenerated from the desired command.
+func convergeCommand(existing, desired string) string {
+	_, rest, found := strings.Cut(existing, hookCommand)
+	if !found {
+		return desired
+	}
+	var extra []string
+	for tok := range strings.FieldsSeq(rest) {
+		if tok == "session-start" || tok == "--verbose" {
+			continue
+		}
+		extra = append(extra, tok)
+	}
+	if len(extra) == 0 {
+		return desired
+	}
+	return desired + " " + strings.Join(extra, " ")
 }
 
-func hasSuffix(s, suffix string) bool {
-	return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix
+// containsHook reports whether cmd is a Leash claude-code hook invocation —
+// through any binary path, possibly followed by a subcommand or flags
+// ("… session-start", "… --verbose"). Trailing shell syntax means the string
+// only mentions the invocation rather than being one, so it is not ours.
+func containsHook(cmd string) bool {
+	_, rest, found := strings.Cut(cmd, hookCommand)
+	if !found {
+		return false
+	}
+	if rest == "" {
+		return true
+	}
+	if rest[0] != ' ' {
+		return false // e.g. "leash hook claude-codex"
+	}
+	for tok := range strings.FieldsSeq(rest) {
+		if strings.ContainsAny(tok, "|&;<>()`$\"'\\") {
+			return false
+		}
+	}
+	return true
 }
 
 func asMap(v any) map[string]any {

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -8,10 +8,24 @@ import (
 	"testing"
 )
 
-const wantCommand = "/opt/homebrew/bin/leash hook claude-code"
+const (
+	wantCommand        = "/opt/homebrew/bin/leash hook claude-code"
+	wantSessionCommand = wantCommand + " session-start"
+)
 
-// hookCommands walks hooks.PreToolUse and returns every hook command string.
-func hookCommands(t *testing.T, path string) []string {
+// testSpecs mirrors desiredHooks with a fixed binary path.
+func testSpecs(verbose bool) []hookSpec {
+	pre := wantCommand
+	if verbose {
+		pre += " --verbose"
+	}
+	return []hookSpec{
+		{event: "PreToolUse", matcher: toolMatcher, command: pre},
+		{event: "SessionStart", matcher: sessionStartMatcher, command: wantSessionCommand},
+	}
+}
+
+func readSettings(t *testing.T, path string) map[string]any {
 	t.Helper()
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -21,8 +35,14 @@ func hookCommands(t *testing.T, path string) []string {
 	if err := json.Unmarshal(data, &settings); err != nil {
 		t.Fatalf("settings not valid JSON: %v", err)
 	}
+	return settings
+}
+
+// hookCommands walks hooks.<event> and returns every hook command string.
+func hookCommands(t *testing.T, path, event string) []string {
+	t.Helper()
 	var cmds []string
-	for _, e := range asSlice(asMap(settings["hooks"])["PreToolUse"]) {
+	for _, e := range asSlice(asMap(readSettings(t, path)["hooks"])[event]) {
 		for _, h := range asSlice(asMap(e)["hooks"]) {
 			if cmd, ok := asMap(h)["command"].(string); ok {
 				cmds = append(cmds, cmd)
@@ -32,47 +52,117 @@ func hookCommands(t *testing.T, path string) []string {
 	return cmds
 }
 
-func TestInstallHook(t *testing.T) {
+func TestInstallHooks(t *testing.T) {
 	tests := []struct {
-		name    string
-		initial string // "" means the settings file does not exist yet
-		want    hookInstallResult
-		cmds    []string // expected hook commands after the call, in order
+		name        string
+		initial     string // "" means the settings file does not exist yet
+		verbose     bool
+		want        hookInstallResult
+		preCmds     []string // expected PreToolUse commands after the call, in order
+		sessionCmds []string // expected SessionStart commands after the call, in order
 	}{
 		{
-			name: "creates settings file and parent dirs",
-			want: hookInstalled,
-			cmds: []string{wantCommand},
+			name:        "creates settings file with both hooks",
+			want:        hookInstalled,
+			preCmds:     []string{wantCommand},
+			sessionCmds: []string{wantSessionCommand},
 		},
 		{
 			name: "appends alongside unrelated hooks",
 			initial: `{"permissions":{"allow":["Bash(ls *)"]},
 				"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"echo hi"}]}]}}`,
-			want: hookInstalled,
-			cmds: []string{"echo hi", wantCommand},
+			want:        hookInstalled,
+			preCmds:     []string{"echo hi", wantCommand},
+			sessionCmds: []string{wantSessionCommand},
 		},
 		{
-			name: "idempotent when the command already matches",
+			// The upgrade path from installs made before the SessionStart
+			// banner existed: PreToolUse is current, the banner hook is not
+			// there yet.
+			name: "adds the session banner to a pre-banner install",
 			initial: `{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[
 				{"type":"command","command":"/opt/homebrew/bin/leash hook claude-code"}]}]}}`,
-			want: hookUnchanged,
-			cmds: []string{wantCommand},
+			want:        hookInstalled,
+			preCmds:     []string{wantCommand},
+			sessionCmds: []string{wantSessionCommand},
+		},
+		{
+			name: "idempotent when both hooks already match",
+			initial: `{"hooks":{
+				"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"/opt/homebrew/bin/leash hook claude-code"}]}],
+				"SessionStart":[{"matcher":"startup|resume|clear","hooks":[{"type":"command","command":"/opt/homebrew/bin/leash hook claude-code session-start"}]}]}}`,
+			want:        hookUnchanged,
+			preCmds:     []string{wantCommand},
+			sessionCmds: []string{wantSessionCommand},
 		},
 		{
 			// The brew-cask trap: a previous init resolved the symlink into a
 			// version-pinned Caskroom path that no longer exists after upgrade.
-			// Re-running init must heal it, not report "already present".
-			name: "heals a stale binary path",
-			initial: `{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[
-				{"type":"command","command":"/opt/homebrew/Caskroom/leash/0.0.2/leash hook claude-code"}]}]}}`,
-			want: hookUpdated,
-			cmds: []string{wantCommand},
+			// Re-running init must heal both hooks, not report "already present".
+			name: "heals stale binary paths in both hooks",
+			initial: `{"hooks":{
+				"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"/opt/homebrew/Caskroom/leash/0.0.2/leash hook claude-code"}]}],
+				"SessionStart":[{"matcher":"startup|resume|clear","hooks":[{"type":"command","command":"/opt/homebrew/Caskroom/leash/0.0.2/leash hook claude-code session-start"}]}]}}`,
+			want:        hookUpdated,
+			preCmds:     []string{wantCommand},
+			sessionCmds: []string{wantSessionCommand},
 		},
 		{
-			name:    "bare PATH command is recognized and healed to absolute",
-			initial: `{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"leash hook claude-code"}]}]}}`,
-			want:    hookUpdated,
-			cmds:    []string{wantCommand},
+			name:        "bare PATH command is recognized and healed to absolute",
+			initial:     `{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"leash hook claude-code"}]}]}}`,
+			want:        hookInstalled, // healed + banner added
+			preCmds:     []string{wantCommand},
+			sessionCmds: []string{wantSessionCommand},
+		},
+		{
+			name: "verbose toggles on",
+			initial: `{"hooks":{
+				"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"/opt/homebrew/bin/leash hook claude-code"}]}],
+				"SessionStart":[{"matcher":"startup|resume|clear","hooks":[{"type":"command","command":"/opt/homebrew/bin/leash hook claude-code session-start"}]}]}}`,
+			verbose:     true,
+			want:        hookUpdated,
+			preCmds:     []string{wantCommand + " --verbose"},
+			sessionCmds: []string{wantSessionCommand},
+		},
+		{
+			name: "verbose toggles back off",
+			initial: `{"hooks":{
+				"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"/opt/homebrew/bin/leash hook claude-code --verbose"}]}],
+				"SessionStart":[{"matcher":"startup|resume|clear","hooks":[{"type":"command","command":"/opt/homebrew/bin/leash hook claude-code session-start"}]}]}}`,
+			want:        hookUpdated,
+			preCmds:     []string{wantCommand},
+			sessionCmds: []string{wantSessionCommand},
+		},
+		{
+			// A flag init doesn't manage (e.g. a hand-added --rules) must ride
+			// along when the stale binary path is healed — dropping it would
+			// silently weaken the user's setup.
+			name: "preserves an unmanaged flag while healing a stale path",
+			initial: `{"hooks":{
+				"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"/opt/homebrew/Caskroom/leash/0.0.2/leash hook claude-code --rules /custom.yaml"}]}],
+				"SessionStart":[{"matcher":"startup|resume|clear","hooks":[{"type":"command","command":"/opt/homebrew/bin/leash hook claude-code session-start"}]}]}}`,
+			want:        hookUpdated,
+			preCmds:     []string{wantCommand + " --rules /custom.yaml"},
+			sessionCmds: []string{wantSessionCommand},
+		},
+		{
+			name: "preserves an unmanaged flag across a verbose toggle",
+			initial: `{"hooks":{
+				"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"/opt/homebrew/bin/leash hook claude-code --rules /custom.yaml"}]}],
+				"SessionStart":[{"matcher":"startup|resume|clear","hooks":[{"type":"command","command":"/opt/homebrew/bin/leash hook claude-code session-start"}]}]}}`,
+			verbose:     true,
+			want:        hookUpdated,
+			preCmds:     []string{wantCommand + " --verbose --rules /custom.yaml"},
+			sessionCmds: []string{wantSessionCommand},
+		},
+		{
+			name: "an unmanaged flag alone is not a change",
+			initial: `{"hooks":{
+				"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"/opt/homebrew/bin/leash hook claude-code --rules /custom.yaml"}]}],
+				"SessionStart":[{"matcher":"startup|resume|clear","hooks":[{"type":"command","command":"/opt/homebrew/bin/leash hook claude-code session-start"}]}]}}`,
+			want:        hookUnchanged,
+			preCmds:     []string{wantCommand + " --rules /custom.yaml"},
+			sessionCmds: []string{wantSessionCommand},
 		},
 	}
 
@@ -88,46 +178,68 @@ func TestInstallHook(t *testing.T) {
 				}
 			}
 
-			got, err := installHook(path, wantCommand)
+			got, err := installHooks(path, testSpecs(tt.verbose))
 			if err != nil {
-				t.Fatalf("installHook: %v", err)
+				t.Fatalf("installHooks: %v", err)
 			}
 			if got != tt.want {
 				t.Fatalf("result = %v, want %v", got, tt.want)
 			}
 
-			cmds := hookCommands(t, path)
-			if len(cmds) != len(tt.cmds) {
-				t.Fatalf("hook commands = %q, want %q", cmds, tt.cmds)
-			}
-			for i := range cmds {
-				if cmds[i] != tt.cmds[i] {
-					t.Fatalf("hook command[%d] = %q, want %q", i, cmds[i], tt.cmds[i])
+			for event, want := range map[string][]string{
+				"PreToolUse":   tt.preCmds,
+				"SessionStart": tt.sessionCmds,
+			} {
+				cmds := hookCommands(t, path, event)
+				if len(cmds) != len(want) {
+					t.Fatalf("%s commands = %q, want %q", event, cmds, want)
+				}
+				for i := range cmds {
+					if cmds[i] != want[i] {
+						t.Fatalf("%s command[%d] = %q, want %q", event, i, cmds[i], want[i])
+					}
 				}
 			}
 		})
 	}
 }
 
-func TestInstallHookPreservesUnrelatedSettings(t *testing.T) {
+// A matcher the user narrowed (e.g. dropped WebFetch) must survive healing:
+// init converges commands, never matchers.
+func TestInstallHooksPreservesCustomMatcher(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	initial := `{"hooks":{
+		"PreToolUse":[{"matcher":"Bash|Write","hooks":[{"type":"command","command":"/stale/leash hook claude-code"}]}],
+		"SessionStart":[{"matcher":"startup","hooks":[{"type":"command","command":"/stale/leash hook claude-code session-start"}]}]}}`
+	if err := os.WriteFile(path, []byte(initial), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, err := installHooks(path, testSpecs(false)); err != nil || got != hookUpdated {
+		t.Fatalf("installHooks = %v, %v; want hookUpdated, nil", got, err)
+	}
+
+	hooks := asMap(readSettings(t, path)["hooks"])
+	if m := asMap(asSlice(hooks["PreToolUse"])[0])["matcher"]; m != "Bash|Write" {
+		t.Errorf("PreToolUse matcher = %v, want the user's Bash|Write kept", m)
+	}
+	if m := asMap(asSlice(hooks["SessionStart"])[0])["matcher"]; m != "startup" {
+		t.Errorf("SessionStart matcher = %v, want the user's startup kept", m)
+	}
+}
+
+func TestInstallHooksPreservesUnrelatedSettings(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "settings.json")
 	initial := `{"permissions":{"allow":["Bash(ls *)"]},"model":"opus"}`
 	if err := os.WriteFile(path, []byte(initial), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := installHook(path, wantCommand); err != nil {
-		t.Fatalf("installHook: %v", err)
+	if _, err := installHooks(path, testSpecs(false)); err != nil {
+		t.Fatalf("installHooks: %v", err)
 	}
 
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var settings map[string]any
-	if err := json.Unmarshal(data, &settings); err != nil {
-		t.Fatal(err)
-	}
+	settings := readSettings(t, path)
 	if settings["model"] != "opus" {
 		t.Errorf("model = %v, want opus", settings["model"])
 	}
@@ -137,16 +249,17 @@ func TestInstallHookPreservesUnrelatedSettings(t *testing.T) {
 	}
 }
 
-func TestInstallHookUnchangedDoesNotRewrite(t *testing.T) {
+func TestInstallHooksUnchangedDoesNotRewrite(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "settings.json")
 	// Deliberately not in MarshalIndent formatting: a rewrite would reformat.
-	initial := `{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"` + wantCommand + `"}]}]}}`
+	initial := `{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"` + wantCommand + `"}]}],` +
+		`"SessionStart":[{"matcher":"startup|resume|clear","hooks":[{"type":"command","command":"` + wantSessionCommand + `"}]}]}}`
 	if err := os.WriteFile(path, []byte(initial), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	if got, err := installHook(path, wantCommand); err != nil || got != hookUnchanged {
-		t.Fatalf("installHook = %v, %v; want hookUnchanged, nil", got, err)
+	if got, err := installHooks(path, testSpecs(false)); err != nil || got != hookUnchanged {
+		t.Fatalf("installHooks = %v, %v; want hookUnchanged, nil", got, err)
 	}
 
 	data, err := os.ReadFile(path)
@@ -158,13 +271,34 @@ func TestInstallHookUnchangedDoesNotRewrite(t *testing.T) {
 	}
 }
 
-func TestInstallHookRejectsInvalidJSON(t *testing.T) {
+func TestInstallHooksRejectsInvalidJSON(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "settings.json")
 	if err := os.WriteFile(path, []byte("{not json"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := installHook(path, wantCommand); err == nil {
+	if _, err := installHooks(path, testSpecs(false)); err == nil {
 		t.Fatal("expected an error for invalid JSON, got nil")
+	}
+}
+
+func TestDesiredHooks(t *testing.T) {
+	specs := desiredHooks(false)
+	if len(specs) != 2 {
+		t.Fatalf("desiredHooks returned %d specs, want 2", len(specs))
+	}
+	if specs[0].event != "PreToolUse" || !strings.HasSuffix(specs[0].command, " hook claude-code") {
+		t.Errorf("PreToolUse spec = %+v", specs[0])
+	}
+	if specs[1].event != "SessionStart" || !strings.HasSuffix(specs[1].command, " hook claude-code session-start") {
+		t.Errorf("SessionStart spec = %+v", specs[1])
+	}
+
+	verbose := desiredHooks(true)
+	if !strings.HasSuffix(verbose[0].command, " hook claude-code --verbose") {
+		t.Errorf("verbose PreToolUse command = %q, want --verbose suffix", verbose[0].command)
+	}
+	if verbose[1].command != specs[1].command {
+		t.Errorf("verbose must not change the SessionStart command, got %q", verbose[1].command)
 	}
 }
 
@@ -192,8 +326,13 @@ func TestContainsHook(t *testing.T) {
 		{"leash hook claude-code", true},
 		{"/opt/homebrew/bin/leash hook claude-code", true},
 		{"/Users/dev/go/bin/leash hook claude-code", true},
+		{"leash hook claude-code session-start", true},
+		{"/opt/homebrew/bin/leash hook claude-code session-start", true},
+		{"/opt/homebrew/bin/leash hook claude-code --verbose", true},
+		{"leash hook claude-codex", false},
 		{"leash check 'rm -rf ~'", false},
 		{"echo leash hook claude-code | wc -l", false},
+		{"leash hook claude-code && rm -rf /", false},
 		{"", false},
 	}
 	for _, tt := range tests {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -33,7 +33,7 @@ func NewRootCommand(version string) *cobra.Command {
 
 	root.AddCommand(
 		newCheckCommand(),
-		newHookCommand(),
+		newHookCommand(version),
 		newInitCommand(),
 		newAddCommand(),
 		newSearchCommand(),
@@ -49,7 +49,7 @@ func NewRootCommand(version string) *cobra.Command {
 // project rulepack (./.leash.yaml), and an explicit --rules file if given.
 // Later packs layer on top of earlier ones, and any pack can pull others in
 // with extends:.
-func buildEngine() (*policy.Engine, error) {
+func buildEngine() (*policy.Engine, int, error) {
 	var st *store.Store
 	dir, err := store.DefaultDir()
 	if err != nil {
@@ -63,16 +63,19 @@ func buildEngine() (*policy.Engine, error) {
 // buildEngineWithStore is buildEngine with its inputs injected for tests.
 // Ambient sources — installed packs and the discovered .leash.yaml — degrade:
 // one that fails to load is skipped with a warning so the rest keep
-// protecting. The explicit --rules file stays a hard error: the user asked
-// for it by name.
-func buildEngineWithStore(st *store.Store, rulesFile string, errw io.Writer) (*policy.Engine, error) {
+// protecting. The int returned counts those skipped sources, so the session
+// banner can say protection is thinner than configured. The explicit --rules
+// file stays a hard error: the user asked for it by name.
+func buildEngineWithStore(st *store.Store, rulesFile string, errw io.Writer) (*policy.Engine, int, error) {
 	res := policy.NewResolver(locator(st))
 	var warnings []string
+	failed := 0
 
 	if st != nil {
 		names, err := st.List()
 		if err != nil {
 			warnings = append(warnings, fmt.Sprintf("reading installed packs: %v (skipped)", err))
+			failed++
 		}
 		for _, name := range names {
 			path, ok := st.Locate(name)
@@ -81,6 +84,7 @@ func buildEngineWithStore(st *store.Store, rulesFile string, errw io.Writer) (*p
 			}
 			if err := res.Add(path); err != nil {
 				warnings = append(warnings, fmt.Sprintf("installed pack %q: %v (skipped)", name, err))
+				failed++
 			}
 		}
 	}
@@ -88,12 +92,13 @@ func buildEngineWithStore(st *store.Store, rulesFile string, errw io.Writer) (*p
 	if discovered := discoverProjectRules(); discovered != "" {
 		if err := res.Add(discovered); err != nil {
 			warnings = append(warnings, fmt.Sprintf("%v (skipped)", err))
+			failed++
 		}
 	}
 
 	if rulesFile != "" {
 		if err := res.Add(rulesFile); err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 	}
 
@@ -104,7 +109,7 @@ func buildEngineWithStore(st *store.Store, rulesFile string, errw io.Writer) (*p
 	for _, w := range warnings {
 		fmt.Fprintf(errw, "leash: %s\n", w)
 	}
-	return engine, nil
+	return engine, failed, nil
 }
 
 // locator adapts a possibly-nil store to a policy.LocateFunc.

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -38,9 +38,12 @@ func chdirEmpty(t *testing.T) string {
 
 func TestBuildEngineNoStoreStillProtects(t *testing.T) {
 	chdirEmpty(t)
-	e, err := buildEngineWithStore(nil, "", &bytes.Buffer{})
+	e, failed, err := buildEngineWithStore(nil, "", &bytes.Buffer{})
 	if err != nil {
 		t.Fatal(err)
+	}
+	if failed != 0 {
+		t.Errorf("failed sources = %d, want 0", failed)
 	}
 	if got := evalShell(t, e, "rm -rf ~"); got != policy.EffectDeny {
 		t.Fatalf("rm -rf ~ = %q, want deny", got)
@@ -61,7 +64,7 @@ rules:
 		t.Fatal(err)
 	}
 
-	e, err := buildEngineWithStore(st, "", &bytes.Buffer{})
+	e, _, err := buildEngineWithStore(st, "", &bytes.Buffer{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,9 +94,12 @@ rules:
 	writeTestFile(t, st.PackPath("broken"), "rules:\n  - id: x\n    effect: nope\n")
 
 	var stderr bytes.Buffer
-	e, err := buildEngineWithStore(st, "", &stderr)
+	e, failed, err := buildEngineWithStore(st, "", &stderr)
 	if err != nil {
 		t.Fatalf("a corrupt installed pack must not abort the engine: %v", err)
+	}
+	if failed != 1 {
+		t.Errorf("failed sources = %d, want 1 (the corrupt pack)", failed)
 	}
 	if !strings.Contains(stderr.String(), "broken") {
 		t.Fatalf("want a warning naming the broken pack, got %q", stderr.String())
@@ -112,9 +118,12 @@ func TestBuildEngineCorruptProjectRulesDegrade(t *testing.T) {
 	writeTestFile(t, filepath.Join(dir, ".leash.yaml"), "rules:\n  - id: x\n    effect: nope\n")
 
 	var stderr bytes.Buffer
-	e, err := buildEngineWithStore(nil, "", &stderr)
+	e, failed, err := buildEngineWithStore(nil, "", &stderr)
 	if err != nil {
 		t.Fatalf("a corrupt .leash.yaml must not abort the engine: %v", err)
+	}
+	if failed != 1 {
+		t.Errorf("failed sources = %d, want 1 (the corrupt .leash.yaml)", failed)
 	}
 	if stderr.Len() == 0 {
 		t.Fatal("want a warning about the corrupt .leash.yaml")
@@ -127,7 +136,7 @@ func TestBuildEngineCorruptProjectRulesDegrade(t *testing.T) {
 func TestBuildEngineCorruptRulesFlagIsLoud(t *testing.T) {
 	chdirEmpty(t)
 	bad := writeTestFile(t, filepath.Join(t.TempDir(), "bad.yaml"), "rules:\n  - id: x\n    effect: nope\n")
-	if _, err := buildEngineWithStore(nil, bad, &bytes.Buffer{}); err == nil {
+	if _, _, err := buildEngineWithStore(nil, bad, &bytes.Buffer{}); err == nil {
 		t.Fatal("an explicit --rules file that fails to load must be an error")
 	}
 }
@@ -145,7 +154,7 @@ func TestBuildEngineLayeringOrder(t *testing.T) {
 	// …and the --rules file has the last word: deny.
 	rules := writeTestFile(t, filepath.Join(t.TempDir(), "rules.yaml"), "name: flag\noverrides:\n  git-force-push: deny\n")
 
-	e, err := buildEngineWithStore(st, rules, &bytes.Buffer{})
+	e, _, err := buildEngineWithStore(st, rules, &bytes.Buffer{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -174,7 +183,7 @@ rules:
 	writeTestFile(t, filepath.Join(dir, ".leash.yaml"), "name: project\nextends: [base]\noverrides:\n  base-marker: ask\n")
 
 	var stderr bytes.Buffer
-	e, err := buildEngineWithStore(st, "", &stderr)
+	e, _, err := buildEngineWithStore(st, "", &stderr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -191,7 +200,7 @@ func TestBuildEngineMissingExtendsTargetWarns(t *testing.T) {
 	writeTestFile(t, filepath.Join(dir, ".leash.yaml"), "name: project\nextends: [ghost]\n")
 
 	var stderr bytes.Buffer
-	e, err := buildEngineWithStore(store.Open(t.TempDir()), "", &stderr)
+	e, _, err := buildEngineWithStore(store.Open(t.TempDir()), "", &stderr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -15,6 +15,7 @@ import (
 // Engine evaluates Actions against an ordered set of rules.
 type Engine struct {
 	rules         []Rule
+	packs         []string
 	defaultEffect Effect
 	home          string
 	warnings      []string
@@ -45,6 +46,7 @@ func NewEngine(packs ...*Rulepack) *Engine {
 		if name == "" {
 			name = "(unnamed pack)"
 		}
+		e.packs = append(e.packs, name)
 		start := len(e.rules)
 		e.rules = append(e.rules, p.Rules...)
 		for i := start; i < len(e.rules); i++ {
@@ -88,6 +90,16 @@ func NewEngine(packs ...*Rulepack) *Engine {
 // override that referenced a rule id no rulepack defines).
 func (e *Engine) Warnings() []string {
 	return e.warnings
+}
+
+// PackCount returns how many rulepacks the engine was built from.
+func (e *Engine) PackCount() int {
+	return len(e.packs)
+}
+
+// RuleCount returns the number of active rules across all packs.
+func (e *Engine) RuleCount() int {
+	return len(e.rules)
 }
 
 // Evaluate returns the decision for an action. When several rules match, the

--- a/internal/policy/engine_test.go
+++ b/internal/policy/engine_test.go
@@ -298,6 +298,29 @@ func TestRecommendedPersistenceDecisions(t *testing.T) {
 	}
 }
 
+func TestEnginePackAndRuleCounts(t *testing.T) {
+	a := &Rulepack{Name: "a", Rules: []Rule{
+		{ID: "a1", Effect: EffectDeny, Match: Match{Regex: "x"}},
+		{ID: "a2", Effect: EffectAsk, Match: Match{Regex: "y"}},
+	}}
+	b := &Rulepack{Name: "b", Rules: []Rule{
+		{ID: "b1", Effect: EffectWarn, Match: Match{Regex: "z"}},
+	}}
+	for _, p := range []*Rulepack{a, b} {
+		if err := p.validate(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	e := NewEngine(a, nil, b) // a nil pack is skipped, not counted
+	if got := e.PackCount(); got != 2 {
+		t.Errorf("PackCount() = %d, want 2", got)
+	}
+	if got := e.RuleCount(); got != 3 {
+		t.Errorf("RuleCount() = %d, want 3", got)
+	}
+}
+
 func TestDenyOverridesAsk(t *testing.T) {
 	// A command that trips both a deny rule and an ask rule must resolve to deny.
 	pack := &Rulepack{

--- a/internal/policy/rule.go
+++ b/internal/policy/rule.go
@@ -24,6 +24,15 @@ type Rule struct {
 // an engine pools the rule — pack authors cannot set it in YAML.
 func (r *Rule) Pack() string { return r.pack }
 
+// Text returns the rule's user-facing explanation: the message written for
+// when the rule fires, else the description.
+func (r *Rule) Text() string {
+	if r.Message != "" {
+		return r.Message
+	}
+	return r.Description
+}
+
 // Match is the condition of a rule. An empty Match never matches (rules must be
 // specific); a non-empty Match requires all of its set conditions to hold.
 type Match struct {


### PR DESCRIPTION
## Why

Leash works, but silently: nothing in a Claude Code session proves it's running, warns ride stderr (which the UI hides), and denials aren't branded. Users asked for a "this session is secured by Leash" signal and per-decision feedback.

## What

**Session banner** — `leash init` now installs a `SessionStart` hook (`startup|resume|clear`, deliberately not `compact`) running `leash hook claude-code session-start`:

> 🐕 Leash v0.1.0 is guarding this session (2 packs, 34 rules)

- Ambient rulepacks that fail to load are called out: `— ⚠️ 1 rulepack failed to load` (the count comes from the skip sites in `buildEngineWithStore`, so degraded protection is never silent).
- If rules can't load at all, the banner says the session is **NOT** being screened instead of pretending — still exit 0, still fail-open.
- The banner rides `systemMessage`; plain stdout on SessionStart would be injected into the model's context instead of shown to the user.

**Decision notices** — deny/ask/warn responses now include a branded one-line `systemMessage` naming the rule (`🐕 Leash is asking first: Force-push detected. … (rule: git-force-push)`). Warn moves off stderr into the chat with **no** permission decision attached, so the call still proceeds. Messages that already speak as Leash aren't double-branded.

**Opt-in verbose** — `leash init --verbose` bakes `--verbose` into the PreToolUse hook: allowed calls get `🐕 Leash allowed this`. This is systemMessage-only — an explicit `permissionDecision: "allow"` would bypass the user's own permission prompts, so Leash never emits one. Tests pin that invariant end to end.

**Init convergence** — one read/mutate/write pass handles both hooks: heals stale binary paths, toggles `--verbose`, adds the missing SessionStart entry to pre-banner installs, and preserves what it doesn't own — user-customized matchers and hand-added flags like `--rules` survive every rewrite.

**Internals** — `policy.Rule.Text()` centralizes the message-or-description fallback; `Engine` gained `PackCount()`/`RuleCount()`; hook entrypoints take injected io streams so the new `hook_test.go` drives the real cobra wiring.

## Upgrade notes

Existing users get the deny/ask/warn notices from the binary upgrade alone (they ride the hook response). The banner needs one `leash init` / `leash init --global` re-run to install the SessionStart entry.

## Test plan

- `go test ./...` green (7 packages), `go vet` + `gofmt` clean.
- New end-to-end tests drive the real root command with isolated `$HOME`: deny JSON shape, silent allow, `--verbose` allow without a permission decision, fail-open on garbage stdin, banner content, failed-pack banner.
- Manually exercised via the hook protocol: banner (clean + broken-pack), deny (`rm -rf ~`), ask (`git push --force`), warn (custom pack), silent/verbose allow, and init healing a stale Caskroom path while keeping `--rules`.
- Protocol choices (systemMessage semantics, SessionStart matchers, stdout-to-context, allow-bypass) verified against the live Claude Code hooks docs during review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnnXU2sqms3xCuuTYbjXfe