### PR TITLE
Make allowed-call chat notices the default; add --quiet to opt out

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ leash init --global   # add the Leash hooks to .claude/settings.json, for every 
 Start a Claude Code session and Leash is live — a banner in the chat confirms
 it (`🐕 Leash is guarding this session…`). Ask the agent for something
 reckless — it gets stopped, or asked to confirm, with a `🐕` notice in the chat
-saying which rule fired. Want a notice for allowed calls too? `leash init
---verbose`.
+saying which rule fired. Allowed calls get a notice too, so you can see Leash
+watching; `leash init --quiet` turns those off.
 
 ```bash
 claude

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -16,14 +16,14 @@ with the pack and rule counts.
 ```bash
 leash init            # project — ./.claude/settings.json
 leash init --global   # global  — ~/.claude/settings.json
-leash init --verbose  # also show a 🐕 chat notice for *allowed* tool calls
+leash init --quiet    # no 🐕 chat notice for *allowed* tool calls
 ```
 
 Deny, ask, and warn decisions always show a `🐕` notice in the chat naming the
-rule that fired; `--verbose` adds one for allowed calls too (noisy, but useful
-for a demo or for building trust). Re-run `init` without the flag to switch
-back — it always converges the hook commands, which is also how a stale binary
-path gets healed after an upgrade. Flags init doesn't manage (say, a
+rule that fired; allowed calls get one too, so you can see Leash watching
+(`--quiet` turns those off). Re-run `init` with or without the flag to
+switch — it always converges the hook commands, which is also how a stale
+binary path gets healed after an upgrade. Flags init doesn't manage (say, a
 hand-added `--rules`) survive that convergence.
 
 Idempotent and non-destructive: it preserves existing settings (including a
@@ -123,7 +123,7 @@ echo '{"cwd":".","tool_name":"Bash","tool_input":{"command":"rm -rf ~"}}' \
 ```
 
 Deny/ask/warn responses carry a `systemMessage` so the decision is visible in
-the chat. With `--verbose`, allowed calls get a notice too — but never an
+the chat. Allowed calls get a notice too (unless `--quiet`) — but never an
 explicit allow decision, so your own permission settings still apply.
 
 `leash hook claude-code session-start` is the `SessionStart` entrypoint: it

--- a/internal/adapter/claudecode/claudecode.go
+++ b/internal/adapter/claudecode/claudecode.go
@@ -99,7 +99,7 @@ func writeContent(tool string, ti toolInput) string {
 // hookOutput is the hook response envelope. SystemMessage is a line Claude
 // Code shows to the user in the chat; HookSpecificOutput carries the
 // permission decision and is omitted entirely when Leash has no opinion
-// (warn feedback, verbose allow feedback, the session banner).
+// (warn feedback, allow feedback, the session banner).
 type hookOutput struct {
 	SystemMessage      string              `json:"systemMessage,omitempty"`
 	HookSpecificOutput *hookSpecificOutput `json:"hookSpecificOutput,omitempty"`
@@ -116,12 +116,13 @@ type hookSpecificOutput struct {
 //   - deny  -> permissionDecision "deny"  (blocks the tool call) + chat notice
 //   - ask   -> permissionDecision "ask"   (forces a user confirmation prompt) + chat notice
 //   - warn  -> no decision emitted; chat notice only; action proceeds
-//   - allow -> nothing emitted so the user's own permission flow is untouched;
-//     with verbose, a chat notice (still no decision) confirms Leash looked
+//   - allow -> a chat notice (no decision) confirms Leash looked, so the
+//     user's own permission flow is untouched; with quiet, nothing at all
 //
 // Emitting an explicit "allow" decision would auto-approve the call and bypass
-// the user's permission settings, so Leash never does — even in verbose mode.
-func WriteDecision(w io.Writer, d policy.Decision, verbose bool) error {
+// the user's permission settings, so Leash never does — the allow notice is
+// feedback only.
+func WriteDecision(w io.Writer, d policy.Decision, quiet bool) error {
 	switch d.Effect {
 	case policy.EffectDeny:
 		return emit(w, hookOutput{
@@ -136,7 +137,7 @@ func WriteDecision(w io.Writer, d policy.Decision, verbose bool) error {
 	case policy.EffectWarn:
 		return emit(w, hookOutput{SystemMessage: systemMessage("flagged this", d)})
 	default:
-		if !verbose {
+		if quiet {
 			return nil
 		}
 		return emit(w, hookOutput{SystemMessage: systemMessage("allowed this", d)})

--- a/internal/adapter/claudecode/claudecode_test.go
+++ b/internal/adapter/claudecode/claudecode_test.go
@@ -84,9 +84,9 @@ func TestWriteDecision(t *testing.T) {
 	rule := &policy.Rule{ID: "rm-recursive-home", Message: "Recursive delete of your home directory"}
 
 	cases := []struct {
-		name    string
-		d       policy.Decision
-		verbose bool
+		name  string
+		d     policy.Decision
+		quiet bool
 
 		wantEmpty    bool   // nothing at all on stdout
 		wantDecision string // hookSpecificOutput.permissionDecision ("" = key must be absent)
@@ -113,15 +113,15 @@ func TestWriteDecision(t *testing.T) {
 			wantMsgParts: []string{"Leash flagged this", "(rule: rm-recursive-home)"},
 		},
 		{
-			name:      "allow stays silent by default",
-			d:         policy.Decision{Effect: policy.EffectAllow},
-			wantEmpty: true,
+			name:         "allow announces without a decision by default",
+			d:            policy.Decision{Effect: policy.EffectAllow},
+			wantMsgParts: []string{"Leash allowed this"},
 		},
 		{
-			name:         "verbose allow announces without a decision",
-			d:            policy.Decision{Effect: policy.EffectAllow},
-			verbose:      true,
-			wantMsgParts: []string{"Leash allowed this"},
+			name:      "quiet allow stays silent",
+			d:         policy.Decision{Effect: policy.EffectAllow},
+			quiet:     true,
+			wantEmpty: true,
 		},
 		{
 			name:         "deny from a pack default has no rule to cite",
@@ -154,7 +154,7 @@ func TestWriteDecision(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			if err := WriteDecision(&buf, tc.d, tc.verbose); err != nil {
+			if err := WriteDecision(&buf, tc.d, tc.quiet); err != nil {
 				t.Fatalf("WriteDecision: %v", err)
 			}
 

--- a/internal/cli/hook.go
+++ b/internal/cli/hook.go
@@ -18,7 +18,7 @@ func newHookCommand(version string) *cobra.Command {
 }
 
 func newClaudeCodeHookCommand(version string) *cobra.Command {
-	var verbose bool
+	var quiet bool
 
 	cmd := &cobra.Command{
 		Use:   "claude-code",
@@ -27,7 +27,7 @@ func newClaudeCodeHookCommand(version string) *cobra.Command {
 			"decision on stdout. Wire it up with `leash init`, or manually as a\n" +
 			"PreToolUse hook running `leash hook claude-code`.\n\n" +
 			"Deny/ask/warn decisions include a chat notice (systemMessage) so the\n" +
-			"user sees Leash act; with --verbose, allowed calls get a notice too.\n\n" +
+			"user sees Leash act; allowed calls get a notice too unless --quiet.\n\n" +
 			"This command fails open: if anything goes wrong, the tool call is\n" +
 			"allowed so the agent is never bricked by Leash.",
 		Args: cobra.NoArgs,
@@ -35,11 +35,17 @@ func newClaudeCodeHookCommand(version string) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runClaudeCodeHook(cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr(), verbose)
+			return runClaudeCodeHook(cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr(), quiet)
 		},
 	}
-	cmd.Flags().BoolVar(&verbose, "verbose", false,
-		"also show a chat notice for allowed tool calls (deny/ask/warn always show one)")
+	cmd.Flags().BoolVar(&quiet, "quiet", false,
+		"don't show a chat notice for allowed tool calls (deny/ask/warn always show one)")
+	// --verbose asked for what is now the default. It must stay accepted —
+	// silently, with no deprecation chatter on stderr — because settings files
+	// written by older `leash init --verbose` runs pass it on every tool call;
+	// rejecting it would fail the hook and leave those sessions unguarded.
+	cmd.Flags().Bool("verbose", true, "")
+	_ = cmd.Flags().MarkHidden("verbose")
 	cmd.AddCommand(newSessionStartHookCommand(version))
 	return cmd
 }
@@ -63,7 +69,7 @@ func newSessionStartHookCommand(version string) *cobra.Command {
 // runClaudeCodeHook always returns nil (exit 0). It communicates decisions
 // through the JSON protocol on out, never through the exit code, and it fails
 // open on any internal error.
-func runClaudeCodeHook(in io.Reader, out, errw io.Writer, verbose bool) error {
+func runClaudeCodeHook(in io.Reader, out, errw io.Writer, quiet bool) error {
 	engine, _, err := buildEngine()
 	if err != nil {
 		fmt.Fprintf(errw, "leash: failed to load rules, allowing: %v\n", err)
@@ -78,7 +84,7 @@ func runClaudeCodeHook(in io.Reader, out, errw io.Writer, verbose bool) error {
 
 	decision := engine.Evaluate(action)
 
-	if err := claudecode.WriteDecision(out, decision, verbose); err != nil {
+	if err := claudecode.WriteDecision(out, decision, quiet); err != nil {
 		fmt.Fprintf(errw, "leash: could not write decision, allowing: %v\n", err)
 	}
 	return nil

--- a/internal/cli/hook_test.go
+++ b/internal/cli/hook_test.go
@@ -47,26 +47,41 @@ func TestHookClaudeCodeDeny(t *testing.T) {
 	}
 }
 
-func TestHookClaudeCodeAllowIsSilent(t *testing.T) {
+func TestHookClaudeCodeAllowAnnounces(t *testing.T) {
 	isolateHome(t)
 	out := runLeash(t, `{"cwd":".","tool_name":"Bash","tool_input":{"command":"ls -la"}}`,
 		"hook", "claude-code")
-	if out != "" {
-		t.Fatalf("an allowed call must produce no output, got:\n%s", out)
+	if !strings.Contains(out, "Leash allowed this") {
+		t.Errorf("allow missing the notice:\n%s", out)
+	}
+	// The bypass guard, end to end: allow feedback must never carry a
+	// permission decision.
+	if strings.Contains(out, "permissionDecision") {
+		t.Fatalf("allow must not emit a permission decision:\n%s", out)
 	}
 }
 
-func TestHookClaudeCodeVerboseAllow(t *testing.T) {
+func TestHookClaudeCodeQuietAllowIsSilent(t *testing.T) {
+	isolateHome(t)
+	out := runLeash(t, `{"cwd":".","tool_name":"Bash","tool_input":{"command":"ls -la"}}`,
+		"hook", "claude-code", "--quiet")
+	if out != "" {
+		t.Fatalf("a quiet allowed call must produce no output, got:\n%s", out)
+	}
+}
+
+// Settings files written by older `leash init --verbose` runs still pass
+// --verbose on every tool call; the flag must stay accepted (it asked for
+// what is now the default) or those hooks would error out and fail open.
+func TestHookClaudeCodeLegacyVerboseFlagStillAccepted(t *testing.T) {
 	isolateHome(t)
 	out := runLeash(t, `{"cwd":".","tool_name":"Bash","tool_input":{"command":"ls -la"}}`,
 		"hook", "claude-code", "--verbose")
 	if !strings.Contains(out, "Leash allowed this") {
-		t.Errorf("verbose allow missing the notice:\n%s", out)
+		t.Errorf("legacy --verbose allow missing the notice:\n%s", out)
 	}
-	// The bypass guard, end to end: verbose feedback must never carry a
-	// permission decision.
 	if strings.Contains(out, "permissionDecision") {
-		t.Fatalf("verbose allow must not emit a permission decision:\n%s", out)
+		t.Fatalf("allow must not emit a permission decision:\n%s", out)
 	}
 }
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -22,8 +22,8 @@ const sessionStartMatcher = "startup|resume|clear"
 
 func newInitCommand() *cobra.Command {
 	var (
-		global  bool
-		verbose bool
+		global bool
+		quiet  bool
 	)
 
 	cmd := &cobra.Command{
@@ -35,14 +35,14 @@ func newInitCommand() *cobra.Command {
 			"settings (./.claude/settings.json); use --global for ~/.claude/settings.json.\n\n" +
 			"The change is idempotent and preserves any existing settings. Re-running\n" +
 			"init always converges the hook commands, so it also heals a stale binary\n" +
-			"path and toggles --verbose on or off.",
+			"path and toggles --quiet on or off.",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			path, err := settingsPath(global)
 			if err != nil {
 				return fail(cmd, err)
 			}
-			result, err := installHooks(path, desiredHooks(verbose))
+			result, err := installHooks(path, desiredHooks(quiet))
 			if err != nil {
 				return fail(cmd, err)
 			}
@@ -61,8 +61,12 @@ func newInitCommand() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&global, "global", false, "install into ~/.claude/settings.json instead of the project")
-	cmd.Flags().BoolVar(&verbose, "verbose", false,
-		"show a chat notice for allowed tool calls too (re-run init without it to switch back)")
+	cmd.Flags().BoolVar(&quiet, "quiet", false,
+		"don't show a chat notice for allowed tool calls (re-run init without it to switch back)")
+	// --verbose asked for what is now the default; running it plain is correct.
+	cmd.Flags().Bool("verbose", true, "")
+	_ = cmd.Flags().MarkDeprecated("verbose",
+		"allowed-call notices are now the default; use --quiet to turn them off")
 	return cmd
 }
 
@@ -91,11 +95,11 @@ type hookSpec struct {
 }
 
 // desiredHooks returns the hook entries `leash init` converges the settings to.
-func desiredHooks(verbose bool) []hookSpec {
+func desiredHooks(quiet bool) []hookSpec {
 	base := hookInvocation()
 	pre := base
-	if verbose {
-		pre += " --verbose"
+	if quiet {
+		pre += " --quiet"
 	}
 	return []hookSpec{
 		{event: "PreToolUse", matcher: toolMatcher, command: pre},
@@ -129,7 +133,7 @@ const (
 
 // installHooks merges the desired hook entries into the settings file at path,
 // creating it if necessary. An existing leash hook whose command differs —
-// e.g. a stale binary path left by a previous install, or a verbose toggle —
+// e.g. a stale binary path left by a previous install, or a quiet toggle —
 // is updated in place, so re-running `leash init` always converges on working
 // hooks.
 func installHooks(path string, specs []hookSpec) (hookInstallResult, error) {
@@ -199,7 +203,8 @@ func installHooks(path string, specs []hookSpec) (hookInstallResult, error) {
 // invocation while keeping any trailing tokens init does not manage (a
 // hand-added --rules, say): the user put them there, and dropping them would
 // silently weaken their setup. The tokens init owns — the session-start
-// subcommand and --verbose — are regenerated from the desired command.
+// subcommand, --quiet, and the legacy --verbose (now the default, so the
+// token is dropped) — are regenerated from the desired command.
 func convergeCommand(existing, desired string) string {
 	_, rest, found := strings.Cut(existing, hookCommand)
 	if !found {
@@ -207,7 +212,7 @@ func convergeCommand(existing, desired string) string {
 	}
 	var extra []string
 	for tok := range strings.FieldsSeq(rest) {
-		if tok == "session-start" || tok == "--verbose" {
+		if tok == "session-start" || tok == "--quiet" || tok == "--verbose" {
 			continue
 		}
 		extra = append(extra, tok)
@@ -220,7 +225,7 @@ func convergeCommand(existing, desired string) string {
 
 // containsHook reports whether cmd is a Leash claude-code hook invocation —
 // through any binary path, possibly followed by a subcommand or flags
-// ("… session-start", "… --verbose"). Trailing shell syntax means the string
+// ("… session-start", "… --quiet"). Trailing shell syntax means the string
 // only mentions the invocation rather than being one, so it is not ours.
 func containsHook(cmd string) bool {
 	_, rest, found := strings.Cut(cmd, hookCommand)

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -14,10 +14,10 @@ const (
 )
 
 // testSpecs mirrors desiredHooks with a fixed binary path.
-func testSpecs(verbose bool) []hookSpec {
+func testSpecs(quiet bool) []hookSpec {
 	pre := wantCommand
-	if verbose {
-		pre += " --verbose"
+	if quiet {
+		pre += " --quiet"
 	}
 	return []hookSpec{
 		{event: "PreToolUse", matcher: toolMatcher, command: pre},
@@ -56,7 +56,7 @@ func TestInstallHooks(t *testing.T) {
 	tests := []struct {
 		name        string
 		initial     string // "" means the settings file does not exist yet
-		verbose     bool
+		quiet       bool
 		want        hookInstallResult
 		preCmds     []string // expected PreToolUse commands after the call, in order
 		sessionCmds []string // expected SessionStart commands after the call, in order
@@ -115,17 +115,29 @@ func TestInstallHooks(t *testing.T) {
 			sessionCmds: []string{wantSessionCommand},
 		},
 		{
-			name: "verbose toggles on",
+			name: "quiet toggles on",
 			initial: `{"hooks":{
 				"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"/opt/homebrew/bin/leash hook claude-code"}]}],
 				"SessionStart":[{"matcher":"startup|resume|clear","hooks":[{"type":"command","command":"/opt/homebrew/bin/leash hook claude-code session-start"}]}]}}`,
-			verbose:     true,
+			quiet:       true,
 			want:        hookUpdated,
-			preCmds:     []string{wantCommand + " --verbose"},
+			preCmds:     []string{wantCommand + " --quiet"},
 			sessionCmds: []string{wantSessionCommand},
 		},
 		{
-			name: "verbose toggles back off",
+			name: "quiet toggles back off",
+			initial: `{"hooks":{
+				"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"/opt/homebrew/bin/leash hook claude-code --quiet"}]}],
+				"SessionStart":[{"matcher":"startup|resume|clear","hooks":[{"type":"command","command":"/opt/homebrew/bin/leash hook claude-code session-start"}]}]}}`,
+			want:        hookUpdated,
+			preCmds:     []string{wantCommand},
+			sessionCmds: []string{wantSessionCommand},
+		},
+		{
+			// The upgrade path from installs made when allowed-call notices were
+			// opt-in: the legacy --verbose token asked for what is now the
+			// default, so converging drops it.
+			name: "legacy --verbose converges to the plain command",
 			initial: `{"hooks":{
 				"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"/opt/homebrew/bin/leash hook claude-code --verbose"}]}],
 				"SessionStart":[{"matcher":"startup|resume|clear","hooks":[{"type":"command","command":"/opt/homebrew/bin/leash hook claude-code session-start"}]}]}}`,
@@ -146,13 +158,13 @@ func TestInstallHooks(t *testing.T) {
 			sessionCmds: []string{wantSessionCommand},
 		},
 		{
-			name: "preserves an unmanaged flag across a verbose toggle",
+			name: "preserves an unmanaged flag across a quiet toggle",
 			initial: `{"hooks":{
 				"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"/opt/homebrew/bin/leash hook claude-code --rules /custom.yaml"}]}],
 				"SessionStart":[{"matcher":"startup|resume|clear","hooks":[{"type":"command","command":"/opt/homebrew/bin/leash hook claude-code session-start"}]}]}}`,
-			verbose:     true,
+			quiet:       true,
 			want:        hookUpdated,
-			preCmds:     []string{wantCommand + " --verbose --rules /custom.yaml"},
+			preCmds:     []string{wantCommand + " --quiet --rules /custom.yaml"},
 			sessionCmds: []string{wantSessionCommand},
 		},
 		{
@@ -178,7 +190,7 @@ func TestInstallHooks(t *testing.T) {
 				}
 			}
 
-			got, err := installHooks(path, testSpecs(tt.verbose))
+			got, err := installHooks(path, testSpecs(tt.quiet))
 			if err != nil {
 				t.Fatalf("installHooks: %v", err)
 			}
@@ -201,6 +213,22 @@ func TestInstallHooks(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// The pre-default spelling `leash init --verbose` must keep parsing (users
+// type it from muscle memory): it asked for what is now the default, so the
+// written hook command carries no token at all.
+func TestInitLegacyVerboseFlagStillAccepted(t *testing.T) {
+	isolateHome(t)
+	runLeash(t, "", "init", "--verbose")
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmds := hookCommands(t, filepath.Join(wd, ".claude", "settings.json"), "PreToolUse")
+	if len(cmds) != 1 || !strings.HasSuffix(cmds[0], " hook claude-code") {
+		t.Fatalf("PreToolUse commands = %q, want one plain hook command", cmds)
 	}
 }
 
@@ -293,12 +321,12 @@ func TestDesiredHooks(t *testing.T) {
 		t.Errorf("SessionStart spec = %+v", specs[1])
 	}
 
-	verbose := desiredHooks(true)
-	if !strings.HasSuffix(verbose[0].command, " hook claude-code --verbose") {
-		t.Errorf("verbose PreToolUse command = %q, want --verbose suffix", verbose[0].command)
+	quiet := desiredHooks(true)
+	if !strings.HasSuffix(quiet[0].command, " hook claude-code --quiet") {
+		t.Errorf("quiet PreToolUse command = %q, want --quiet suffix", quiet[0].command)
 	}
-	if verbose[1].command != specs[1].command {
-		t.Errorf("verbose must not change the SessionStart command, got %q", verbose[1].command)
+	if quiet[1].command != specs[1].command {
+		t.Errorf("quiet must not change the SessionStart command, got %q", quiet[1].command)
 	}
 }
 
@@ -328,7 +356,8 @@ func TestContainsHook(t *testing.T) {
 		{"/Users/dev/go/bin/leash hook claude-code", true},
 		{"leash hook claude-code session-start", true},
 		{"/opt/homebrew/bin/leash hook claude-code session-start", true},
-		{"/opt/homebrew/bin/leash hook claude-code --verbose", true},
+		{"/opt/homebrew/bin/leash hook claude-code --quiet", true},
+		{"/opt/homebrew/bin/leash hook claude-code --verbose", true}, // legacy installs
 		{"leash hook claude-codex", false},
 		{"leash check 'rm -rf ~'", false},
 		{"echo leash hook claude-code | wc -l", false},


### PR DESCRIPTION
## What

Allowed tool calls now get the `🐕 Leash allowed this` chat notice by default — previously opt-in via `--verbose`. A new `--quiet` flag on `leash hook claude-code` and `leash init` turns it off.

## Why

The notices are how Leash earns trust: they show it watching, not just interrupting. Flipping the default in the **hook binary itself** (not just in what `init` writes) means every existing install picks it up on the next binary upgrade, with no re-run of `init`.

## Back-compat

- `--verbose` stays accepted on the hook command — hidden and silent. Settings files written by older `leash init --verbose` runs pass it on every tool call; rejecting it would fail the hook, which fails open and leaves those sessions unguarded. Pinned by `TestHookClaudeCodeLegacyVerboseFlagStillAccepted`.
- `leash init --verbose` still parses (deprecated, with a nudge toward `--quiet`) and writes the plain command — correct, since what it asked for is now the default.
- Re-running plain `leash init` converges a legacy `... --verbose` hook command to the plain one; unmanaged flags (e.g. a hand-added `--rules`) still ride along.
- The bypass guard is unchanged: allow notices never carry a `permissionDecision`, so the user's own permission settings still apply.

## Testing

- `go test ./...`, `go vet`, `gofmt` clean; table-driven cases updated to pin the new default and the safe cases (quiet allow, legacy flag, token convergence).
- Exercised end-to-end with the built binary: default/quiet/legacy-verbose allow paths, deny still denying, and `init` fresh / `--quiet` / legacy-convergence / deprecation-nudge scenarios.

Note for the next release: existing users start seeing allow notices after upgrading the binary — worth a line in the release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012qPofLoHGaRvuXCkEQkw6C