### PR TITLE
Freeze and version the public contracts (rulepack schema marker)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -136,6 +136,30 @@ Every variant always exits 0 and **fails open**: if the input can't be
 understood or the rules can't load, the tool call proceeds as if Leash weren't
 there — and the session banner says so instead of pretending you're covered.
 
+### The `claude-code` envelope (frozen at 1.0)
+
+What the hook reads and writes is a public contract — anything scripting
+against it can rely on this shape for all of Leash 1.x.
+
+**Input** (Claude Code's `PreToolUse` JSON on stdin): `cwd`, `tool_name`, and
+from `tool_input` the fields `command` (Bash), `file_path` (Write / Edit /
+MultiEdit / NotebookEdit / Read), `url` (WebFetch), plus the written content
+(`content`, `new_string`, `edits[].new_string`) for the manifest-hook
+detector. Unknown tools and missing fields degrade to "nothing to evaluate" —
+never an error.
+
+**Output** (stdout), by decision:
+
+| Decision | `hookSpecificOutput.permissionDecision` | `systemMessage` |
+|---|---|---|
+| deny | `"deny"` + the rule's message as the reason | 🐕 notice naming the rule |
+| ask | `"ask"` + the rule's message as the reason | 🐕 notice naming the rule |
+| warn | *absent* — the call proceeds | 🐕 notice naming the rule |
+| allow | *absent* — **never emitted** | 🐕 notice, unless `--quiet` (then no output at all) |
+
+An explicit `"allow"` decision is never written: it would override permission
+settings you configured in Claude Code itself. Leash only ever tightens.
+
 ## `leash version`
 
 Prints the version.

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -93,6 +93,7 @@ A pack is a normal rulepack file — same schema as `.leash.yaml`
 ([full reference](rules.md)):
 
 ```yaml
+schema: 1                     # rulepack format generation (see rules.md)
 name: terraform-safety        # must match its registry name
 rules:
   - id: terraform-destroy    # prefix ids with your pack's theme: no collisions
@@ -163,6 +164,17 @@ An index is just `index.yaml` (`schema: 1`, a `packs:` list as above) with
 pack `path`s resolved relative to it. A git repo, an S3 bucket, or a directory
 all work. Air-gapped teams can vendor the whole registry and point at the
 checkout.
+
+## Compatibility
+
+The index format is a public contract, frozen at Leash 1.0: `schema: 1` and
+the entry fields above (`name`, `description`, `version`, `sha256`, `path`,
+`tags`, `maintainer`) keep their meaning for all of 1.x. An index declaring a
+newer `schema` than the binary understands fails loudly — `add`, `search`,
+and `update` refuse with an "upgrade leash" message rather than misreading
+it. Pack files carry their own `schema:` marker with the same promise;
+[rules.md](rules.md#schema-version--compatibility) spells out what is frozen
+and how a newer-schema pack degrades at load time.
 
 ---
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -23,6 +23,7 @@ leash check --rules ./team.yaml 'rm -rf ~'   # plus your pack
 ## Anatomy of a rule
 
 ```yaml
+schema: 1           # rulepack format generation (optional; absent means 1)
 name: my-rules      # optional label
 default: allow      # effect when nothing matches (default: allow)
 
@@ -117,6 +118,38 @@ overrides:
 
 An override aimed at an unknown id is reported on stderr and ignored — it never
 breaks the agent.
+
+## Schema version & compatibility
+
+The rulepack format is a public contract, frozen at Leash 1.0. A pack declares
+the format generation it requires with `schema:`; a missing marker means `1`,
+so every pack published before the marker existed stays valid.
+
+**Frozen for all of Leash 1.x** — these keep their exact meaning:
+
+- every field above (`schema`, `name`, `default`, `extends`, `overrides`,
+  `rules` and the rule fields),
+- every match condition name and what it fires on,
+- effect resolution (`deny` > `ask` > `warn` > `allow`, most severe wins),
+- `extends:` semantics (extender wins, dedup, missing target degrades),
+- the layering order (`recommended` < installed < `./.leash.yaml` < `--rules`).
+
+**What may evolve:** minor releases may *add* match conditions and fields.
+When an addition is something a rule can depend on (a new match condition),
+the schema generation bumps, and a pack using it declares the new number —
+e.g. `schema: 2`.
+
+A pack that requires a newer schema than the binary understands is **refused
+whole**, never half-read: from an ambient source (an installed pack,
+`./.leash.yaml`) it is skipped with an "upgrade leash" warning while every
+other pack keeps protecting; named explicitly via `--rules` it is a hard
+error. Half-reading is the one thing the loader will never do — a match
+condition silently dropped from a rule would make the rule *broader*, the
+wrong failure direction for a tool that promises near-zero false positives.
+
+In semver terms: a **patch** never changes the contract, a **minor** may add
+vocabulary (bumping the schema generation packs can opt into), and only a
+**major** may change or remove the meaning of anything listed above.
 
 ## More
 

--- a/examples/custom-rules.yaml
+++ b/examples/custom-rules.yaml
@@ -7,6 +7,7 @@
 #
 # Rules here are evaluated together with the recommended pack. When several rules
 # match, the most severe effect wins (deny > ask > warn > allow).
+schema: 1
 name: custom-example
 default: allow
 

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -141,6 +141,54 @@ func TestBuildEngineCorruptRulesFlagIsLoud(t *testing.T) {
 	}
 }
 
+// futurePack declares a rulepack schema newer than this build understands —
+// e.g. published for a leash with match vocabulary this binary lacks.
+const futurePack = `schema: 99
+name: future
+rules:
+  - id: future-marker
+    description: test
+    effect: deny
+    match:
+      regex: 'zzz-future-marker'
+`
+
+// A newer-schema pack degrades exactly like a corrupt one when it arrives
+// through an ambient source: warned, skipped, everything else keeps protecting.
+func TestBuildEngineNewerSchemaPackDegrades(t *testing.T) {
+	chdirEmpty(t)
+	st := store.Open(t.TempDir())
+	writeTestFile(t, st.PackPath("future"), futurePack)
+
+	var stderr bytes.Buffer
+	e, failed, err := buildEngineWithStore(st, "", &stderr)
+	if err != nil {
+		t.Fatalf("a newer-schema installed pack must not abort the engine: %v", err)
+	}
+	if failed != 1 {
+		t.Errorf("failed sources = %d, want 1 (the newer-schema pack)", failed)
+	}
+	if !strings.Contains(stderr.String(), "upgrade leash") {
+		t.Fatalf("want a warning telling the user to upgrade, got %q", stderr.String())
+	}
+	// The skipped pack's rules must not be half-applied.
+	if got := evalShell(t, e, "echo zzz-future-marker"); got != policy.EffectAllow {
+		t.Fatalf("rule from a skipped newer-schema pack fired: %q", got)
+	}
+	if got := evalShell(t, e, "rm -rf ~"); got != policy.EffectDeny {
+		t.Fatalf("rm -rf ~ = %q, want deny", got)
+	}
+}
+
+func TestBuildEngineNewerSchemaRulesFlagIsLoud(t *testing.T) {
+	chdirEmpty(t)
+	future := writeTestFile(t, filepath.Join(t.TempDir(), "future.yaml"), futurePack)
+	_, _, err := buildEngineWithStore(nil, future, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "upgrade leash") {
+		t.Fatalf("an explicit --rules file with a newer schema must fail loudly, got %v", err)
+	}
+}
+
 // Layering order: recommended < installed < .leash.yaml < --rules.
 func TestBuildEngineLayeringOrder(t *testing.T) {
 	dir := chdirEmpty(t)

--- a/internal/policy/builtin/recommended.yaml
+++ b/internal/policy/builtin/recommended.yaml
@@ -5,6 +5,7 @@
 # anything a developer might legitimately mean, we ask for confirmation instead
 # of blocking. Everyday operations (rm -rf node_modules, rm -rf ./dist, rm -rf *)
 # are deliberately NOT matched.
+schema: 1
 name: recommended
 default: allow
 

--- a/internal/policy/rule.go
+++ b/internal/policy/rule.go
@@ -91,8 +91,18 @@ func (r *Rule) compile() error {
 	if !r.Effect.Valid() {
 		return fmt.Errorf("rule %q has invalid effect %q", r.ID, r.Effect)
 	}
+	if err := validateSeverity(r.ID, r.Severity); err != nil {
+		return err
+	}
 	if r.Match.isEmpty() {
 		return fmt.Errorf("rule %q has an empty match (would never fire)", r.ID)
+	}
+	for _, k := range r.Match.Tool {
+		switch k {
+		case ActionShell, ActionFileWrite, ActionFileRead, ActionNetFetch:
+		default:
+			return fmt.Errorf("rule %q has invalid tool %q", r.ID, k)
+		}
 	}
 	if sh := r.Match.Shell; sh != nil {
 		if err := validateTargetSpec(r.ID, "delete_target", sh.DeleteTarget); err != nil {
@@ -140,5 +150,14 @@ func validateSecretSpec(ruleID, field, spec string) error {
 		return nil
 	default:
 		return fmt.Errorf("rule %q has invalid %s %q", ruleID, field, spec)
+	}
+}
+
+func validateSeverity(ruleID, severity string) error {
+	switch severity {
+	case "", "info", "low", "medium", "high", "critical":
+		return nil
+	default:
+		return fmt.Errorf("rule %q has invalid severity %q", ruleID, severity)
 	}
 }

--- a/internal/policy/rulepack.go
+++ b/internal/policy/rulepack.go
@@ -13,10 +13,22 @@ import (
 //go:embed builtin/recommended.yaml
 var builtinFS embed.FS
 
+// RulepackSchema is the rulepack format generation this build understands.
+// It bumps whenever the schema grows vocabulary a rule can depend on (a new
+// match condition, say). A pack declaring a newer schema is refused at load
+// rather than half-read: the YAML decoder drops unknown fields silently, and
+// a match condition dropped from a rule makes the rule broader, not narrower
+// — an unacceptable failure direction for a tool that promises near-zero
+// false positives.
+const RulepackSchema = 1
+
 // Rulepack is a named, shareable collection of rules — the unit users publish
 // and compose. The shipped "recommended" pack is embedded in the binary.
 type Rulepack struct {
-	Name string `yaml:"name"`
+	// Schema is the rulepack format generation this pack requires. Zero
+	// (absent) means 1, keeping packs published before the marker valid.
+	Schema int    `yaml:"schema,omitempty"`
+	Name   string `yaml:"name"`
 	// Default is the effect applied when no rule matches. Last pack to set it wins.
 	Default Effect `yaml:"default,omitempty"`
 	// Extends pulls other packs in below this one: each entry is an installed
@@ -79,6 +91,13 @@ func Recommended() *Rulepack {
 }
 
 func (p *Rulepack) validate() error {
+	if p.Schema < 0 {
+		return fmt.Errorf("rulepack %q has invalid schema %d", p.Name, p.Schema)
+	}
+	if p.Schema > RulepackSchema {
+		return fmt.Errorf("rulepack %q requires schema %d, but this leash understands up to %d — upgrade leash",
+			p.Name, p.Schema, RulepackSchema)
+	}
 	if p.Default != "" && !p.Default.Valid() {
 		return fmt.Errorf("rulepack %q has invalid default effect %q", p.Name, p.Default)
 	}

--- a/internal/policy/rulepack_test.go
+++ b/internal/policy/rulepack_test.go
@@ -1,0 +1,149 @@
+package policy
+
+import (
+	"strings"
+	"testing"
+)
+
+// The schema marker is the forward-compatibility gate: a pack that requires
+// vocabulary this build does not have must be refused whole, never half-read
+// (the YAML decoder drops unknown fields silently, and a dropped match
+// condition makes a rule broader — the wrong failure direction).
+func TestLoadSchemaVersion(t *testing.T) {
+	cases := []struct {
+		name    string
+		yaml    string
+		wantErr string // empty = must load
+	}{
+		{
+			name: "absent schema means v1",
+			yaml: `name: t
+rules:
+  - id: r
+    description: d
+    effect: deny
+    match: {regex: 'x'}
+`,
+		},
+		{
+			name: "current schema loads",
+			yaml: `schema: 1
+name: t
+rules:
+  - id: r
+    description: d
+    effect: deny
+    match: {regex: 'x'}
+`,
+		},
+		{
+			name: "newer schema is refused with an upgrade hint",
+			yaml: `schema: 2
+name: t
+rules:
+  - id: r
+    description: d
+    effect: deny
+    match: {regex: 'x'}
+`,
+			wantErr: "upgrade leash",
+		},
+		{
+			name:    "negative schema is invalid",
+			yaml:    "schema: -1\nname: t\nrules: []\n",
+			wantErr: "invalid schema",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Load(strings.NewReader(tc.yaml))
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Load() = %v, want ok", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("Load() = %v, want error containing %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// severity and tool are closed vocabularies: a typo must fail at load, not
+// silently change what the rule matches or how it displays.
+func TestLoadFieldValidation(t *testing.T) {
+	cases := []struct {
+		name    string
+		yaml    string
+		wantErr string // empty = must load
+	}{
+		{
+			name: "documented severities load",
+			yaml: `name: t
+rules:
+  - id: a
+    description: d
+    severity: info
+    effect: warn
+    match: {regex: 'x'}
+  - id: b
+    description: d
+    severity: critical
+    effect: deny
+    match: {regex: 'x'}
+`,
+		},
+		{
+			name: "unknown severity is refused",
+			yaml: `name: t
+rules:
+  - id: r
+    description: d
+    severity: catastrophic
+    effect: deny
+    match: {regex: 'x'}
+`,
+			wantErr: `invalid severity "catastrophic"`,
+		},
+		{
+			name: "known tool kinds load",
+			yaml: `name: t
+rules:
+  - id: r
+    description: d
+    effect: ask
+    match:
+      tool: [shell, file_write, file_read, net_fetch]
+      regex: 'x'
+`,
+		},
+		{
+			name: "unknown tool kind is refused",
+			yaml: `name: t
+rules:
+  - id: r
+    description: d
+    effect: ask
+    match:
+      tool: [Shell]
+      regex: 'x'
+`,
+			wantErr: `invalid tool "Shell"`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Load(strings.NewReader(tc.yaml))
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Load() = %v, want ok", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("Load() = %v, want error containing %q", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/registry/index.yaml
+++ b/registry/index.yaml
@@ -9,24 +9,24 @@ schema: 1
 packs:
   - name: terraform-safety
     description: Block terraform destroy; confirm state mutations and unreviewed applies
-    version: "1.0.0"
-    sha256: b87e4b899a574be6a3818acd96ebcaac7a6a155eb3068d224cef7df0336f057a
+    version: "1.0.1"
+    sha256: 0d558df470375f311a07c849b2d71f7593df85665bb59ba3bd0fac572450ec62
     path: packs/terraform-safety.yaml
     tags: [terraform, tofu, infra, iac]
     maintainer: hoophq
 
   - name: prod-db-guard
     description: Confirm production database sessions and destructive SQL from CLI clients
-    version: "1.0.0"
-    sha256: 284d89b86e36417940b71ad6ab9ed8da62bde554d2af6ffa7ecd410dd09372f7
+    version: "1.0.1"
+    sha256: bcc1e107ba46591cc86e2865d89dbd650ba16e8ad8535138d635496b3af6e6f3
     path: packs/prod-db-guard.yaml
     tags: [database, postgres, mysql, mongodb, production]
     maintainer: hoophq
 
   - name: k8s-safety
     description: Confirm namespace deletes, --all sweeps, and node drains; warn on prod contexts
-    version: "1.0.0"
-    sha256: 27afb468f7fc160fcb20d337146ff991eef55953e381b70a0af3604d27388de6
+    version: "1.0.1"
+    sha256: 5eabed4bbb2614646d397e891265b4191f2b5fb1496293fa5553c6f2bfbc2e23
     path: packs/k8s-safety.yaml
     tags: [kubernetes, kubectl, infra]
     maintainer: hoophq

--- a/registry/packs/k8s-safety.yaml
+++ b/registry/packs/k8s-safety.yaml
@@ -5,6 +5,7 @@
 # stay silent.
 #
 # Install:  leash add k8s-safety
+schema: 1
 name: k8s-safety
 
 rules:

--- a/registry/packs/prod-db-guard.yaml
+++ b/registry/packs/prod-db-guard.yaml
@@ -4,6 +4,7 @@
 # the common CLI clients. Everyday local development queries stay silent.
 #
 # Install:  leash add prod-db-guard
+schema: 1
 name: prod-db-guard
 
 rules:

--- a/registry/packs/terraform-safety.yaml
+++ b/registry/packs/terraform-safety.yaml
@@ -5,6 +5,7 @@
 #
 # Install:  leash add terraform-safety
 # Soften:   overrides: { terraform-destroy: ask }  in your .leash.yaml
+schema: 1
 name: terraform-safety
 
 rules:


### PR DESCRIPTION
Implements [ATR-37](https://linear.app/hoophq/issue/ATR-37/freeze-and-version-the-public-contracts-rulepack-schema-registry-index): 1.0 is a compatibility promise, and this pins the three public interfaces — the rulepack YAML schema, the registry index format, and the claude-code hook envelope.

## What changed

- **`schema:` marker on rulepacks** (`RulepackSchema = 1`). Absent means 1, so every pack published before the marker stays valid.
- **Newer-schema packs are refused whole, never half-read.** The YAML decoder drops unknown fields silently, and an all-empty `shell:` match matches *every* command — so a rule whose only condition is a newer, unknown predicate would silently become "deny everything" on an old binary. Refusing the pack at load routes it through the existing degrade split: ambient sources (installed packs, `./.leash.yaml`) warn + skip with an "upgrade leash" hint while the rest keep protecting; an explicit `--rules` file stays a hard error.
- **Two documented-but-unenforced vocabularies now validate at load:** `severity` (`info|low|medium|high|critical`) and `match.tool` kinds (`shell|file_write|file_read|net_fetch`). Previously a typo like `tool: [Shell]` silently never matched.
- **The marker ships everywhere we publish:** embedded `recommended` pack, the three seed packs (checksums recomputed, versions bumped to 1.0.1), and `examples/custom-rules.yaml`.
- **Docs:** `rules.md` gains the "Schema version & compatibility" section (what's frozen for 1.x, what a patch/minor/major may change); `registry.md` freezes the index format; `cli.md` documents the frozen claude-code hook envelope (input fields read, output per decision, and the never-emit-allow invariant).

## Test plan

- `internal/policy/rulepack_test.go`: table-driven — absent schema loads, `schema: 1` loads, `schema: 2` refused with the upgrade hint, negative invalid; severity and tool vocabulary catch + safe cases.
- `internal/cli/root_test.go`: a `schema: 99` installed pack degrades (warned, skipped, its rules don't half-fire, `rm -rf ~` still denied); the same pack via `--rules` fails loud.
- Verified end-to-end with the built binary: loud error + exit 1 on `--rules` with a future pack, normal ALLOW with a `schema: 1` pack.
- `gofmt` / `go vet` / `go test ./...` all green (includes the seed-registry checksum test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FubmMTgfqah1rKE4bLHZ9v