### PR TITLE
Add leash uninstall: the exit door for the Claude Code hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,11 @@ watching; `leash init --quiet` turns those off.
 claude
 ```
 
-**→ [All CLI commands](docs/cli.md)** — `init`, `check` (test a verdict without
-an agent), `add`/`search` (rulepacks), `hook`, and `version`.
+And here's how you leave: `leash uninstall` removes exactly the hooks `init`
+added and touches nothing else. Dev-owned means you can walk away cleanly.
+
+**→ [All CLI commands](docs/cli.md)** — `init`/`uninstall`, `check` (test a
+verdict without an agent), `add`/`search` (rulepacks), `hook`, and `version`.
 
 ---
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -30,6 +30,24 @@ Idempotent and non-destructive: it preserves existing settings (including a
 matcher you've customized) and won't add the hooks twice. Restart Claude Code
 (or start a new session) to activate them.
 
+## `leash uninstall`
+
+The exit door: removes the hooks `leash init` installed — and nothing else.
+Unrelated hooks, customized matchers on other entries, and every other
+setting in the file stay exactly as they were; containers that existed only
+to hold the Leash hooks are cleaned up rather than left empty. Running it
+when nothing is installed is a friendly no-op.
+
+```bash
+leash uninstall            # project — ./.claude/settings.json
+leash uninstall --global   # global  — ~/.claude/settings.json
+```
+
+It recognizes the hooks the same way `init` heals them, so a stale binary
+path or a hand-added flag doesn't stop the removal. Rulepacks installed with
+`leash add` are separate — remove those with [`leash remove`](#leash-remove),
+or delete `~/.leash` to clear every trace.
+
 ## `leash search`
 
 Discover rulepacks published in the [registry](registry.md). With no query,

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -35,6 +35,7 @@ func NewRootCommand(version string) *cobra.Command {
 		newCheckCommand(),
 		newHookCommand(version),
 		newInitCommand(),
+		newUninstallCommand(),
 		newAddCommand(),
 		newSearchCommand(),
 		newRemoveCommand(),

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -1,0 +1,132 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func newUninstallCommand() *cobra.Command {
+	var global bool
+
+	cmd := &cobra.Command{
+		Use:   "uninstall",
+		Short: "Remove the Leash hooks from Claude Code settings",
+		Long: "The exit door: removes the hooks `leash init` installed from your Claude\n" +
+			"Code settings, leaving everything else in the file untouched. By default\n" +
+			"it edits the project settings (./.claude/settings.json); use --global for\n" +
+			"~/.claude/settings.json.\n\n" +
+			"Rulepacks installed with `leash add` are not touched — remove those with\n" +
+			"`leash remove <pack>`.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			path, err := settingsPath(global)
+			if err != nil {
+				return fail(cmd, err)
+			}
+			result, err := removeHooks(path)
+			if err != nil {
+				return fail(cmd, err)
+			}
+			switch result {
+			case hookRemoved:
+				fmt.Fprintf(cmd.OutOrStdout(), "Removed the Leash hooks from %s\n", path)
+				fmt.Fprintf(cmd.OutOrStdout(), "Restart Claude Code (or start a new session) for the change to take effect.\n")
+			default:
+				fmt.Fprintf(cmd.OutOrStdout(), "No Leash hooks found in %s\n", path)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&global, "global", false, "remove from ~/.claude/settings.json instead of the project")
+	return cmd
+}
+
+// hookRemoveResult describes what removeHooks changed.
+type hookRemoveResult int
+
+const (
+	hookAbsent hookRemoveResult = iota
+	hookRemoved
+)
+
+// removeHooks deletes exactly the Leash hook commands from the settings file
+// at path — recognized the same way init converges them, via containsHook, so
+// a stale binary path, a hand-added flag, or a user-narrowed matcher all
+// still count as ours. Containers that held only Leash entries are removed
+// too (an entry whose hooks list empties, an event whose entries empty, the
+// hooks key itself), so init followed by uninstall leaves the settings as
+// they were. Everything else is preserved, and when there is nothing to
+// remove the file is not rewritten — or created.
+func removeHooks(path string) (hookRemoveResult, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return hookAbsent, nil
+		}
+		return hookAbsent, err
+	}
+	if len(data) == 0 {
+		return hookAbsent, nil
+	}
+	settings := map[string]any{}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return hookAbsent, fmt.Errorf("%s is not valid JSON: %w", path, err)
+	}
+
+	hooks := asMap(settings["hooks"])
+	removed := false
+	for _, event := range []string{"PreToolUse", "SessionStart"} {
+		entries := asSlice(hooks[event])
+		if entries == nil {
+			continue
+		}
+		keptEntries := make([]any, 0, len(entries))
+		for _, e := range entries {
+			em := asMap(e)
+			inner := asSlice(em["hooks"])
+			keptInner := make([]any, 0, len(inner))
+			for _, h := range inner {
+				if cmd, ok := asMap(h)["command"].(string); ok && containsHook(cmd) {
+					removed = true
+					continue
+				}
+				keptInner = append(keptInner, h)
+			}
+			if len(keptInner) == 0 && len(inner) > 0 {
+				continue // the entry existed only to hold Leash hooks
+			}
+			if len(keptInner) < len(inner) {
+				em["hooks"] = keptInner
+			}
+			keptEntries = append(keptEntries, e)
+		}
+		if len(keptEntries) == 0 {
+			delete(hooks, event)
+		} else {
+			hooks[event] = keptEntries
+		}
+	}
+
+	if !removed {
+		return hookAbsent, nil
+	}
+	if len(hooks) == 0 {
+		delete(settings, "hooks")
+	} else {
+		settings["hooks"] = hooks
+	}
+
+	out, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return hookAbsent, err
+	}
+	out = append(out, '\n')
+	if err := os.WriteFile(path, out, 0o644); err != nil {
+		return hookAbsent, err
+	}
+	return hookRemoved, nil
+}

--- a/internal/cli/uninstall_test.go
+++ b/internal/cli/uninstall_test.go
@@ -1,0 +1,192 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestRemoveHooks(t *testing.T) {
+	leashOnly := `{"hooks":{
+		"PreToolUse":[{"matcher":"Bash|Write","hooks":[{"type":"command","command":"` + wantCommand + `"}]}],
+		"SessionStart":[{"matcher":"startup|resume|clear","hooks":[{"type":"command","command":"` + wantSessionCommand + `"}]}]}}`
+
+	tests := []struct {
+		name    string
+		initial string // "" = missing file
+		want    hookRemoveResult
+		// wantCmds is what hookCommands must return per event afterwards.
+		preCmds     []string
+		sessionCmds []string
+	}{
+		{
+			name:    "removes both hooks",
+			initial: leashOnly,
+			want:    hookRemoved,
+		},
+		{
+			name:    "missing file is a no-op",
+			initial: "",
+			want:    hookAbsent,
+		},
+		{
+			name: "quiet and stale-path variants are still ours",
+			initial: `{"hooks":{
+				"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"/stale/leash hook claude-code --quiet"}]}],
+				"SessionStart":[{"matcher":"startup","hooks":[{"type":"command","command":"leash hook claude-code session-start"}]}]}}`,
+			want: hookRemoved,
+		},
+		{
+			name: "a hand-added flag does not hide the hook",
+			initial: `{"hooks":{
+				"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"` + wantCommand + ` --rules /custom.yaml"}]}]}}`,
+			want: hookRemoved,
+		},
+		{
+			name: "an unrelated hook in the same event survives",
+			initial: `{"hooks":{
+				"PreToolUse":[
+					{"matcher":"Bash","hooks":[{"type":"command","command":"echo hi"}]},
+					{"matcher":"Bash|Write","hooks":[{"type":"command","command":"` + wantCommand + `"}]}]}}`,
+			want:    hookRemoved,
+			preCmds: []string{"echo hi"},
+		},
+		{
+			name: "an unrelated command sharing our entry survives",
+			initial: `{"hooks":{
+				"PreToolUse":[{"matcher":"Bash","hooks":[
+					{"type":"command","command":"` + wantCommand + `"},
+					{"type":"command","command":"echo hi"}]}]}}`,
+			want:    hookRemoved,
+			preCmds: []string{"echo hi"},
+		},
+		{
+			name: "a string that merely mentions the invocation is not ours",
+			initial: `{"hooks":{
+				"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"echo leash hook claude-code | wc -l"}]}]}}`,
+			want:    hookAbsent,
+			preCmds: []string{"echo leash hook claude-code | wc -l"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), ".claude", "settings.json")
+			if tt.initial != "" {
+				writeTestFile(t, path, tt.initial)
+			}
+
+			got, err := removeHooks(path)
+			if err != nil {
+				t.Fatalf("removeHooks: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("result = %v, want %v", got, tt.want)
+			}
+
+			if tt.initial == "" {
+				if _, err := os.Stat(path); !os.IsNotExist(err) {
+					t.Fatal("uninstall must not create the settings file")
+				}
+				return
+			}
+			for event, want := range map[string][]string{
+				"PreToolUse":   tt.preCmds,
+				"SessionStart": tt.sessionCmds,
+			} {
+				cmds := hookCommands(t, path, event)
+				if !reflect.DeepEqual(cmds, want) {
+					t.Fatalf("%s commands = %q, want %q", event, cmds, want)
+				}
+			}
+		})
+	}
+}
+
+// init followed by uninstall must hand the file back as it was: unrelated
+// settings intact, no empty hooks containers left behind.
+func TestRemoveHooksRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	writeTestFile(t, path, `{"permissions":{"allow":["Bash(ls *)"]},"model":"opus"}`)
+
+	if _, err := installHooks(path, testSpecs(false)); err != nil {
+		t.Fatalf("installHooks: %v", err)
+	}
+	if got, err := removeHooks(path); err != nil || got != hookRemoved {
+		t.Fatalf("removeHooks = %v, %v; want hookRemoved, nil", got, err)
+	}
+
+	settings := readSettings(t, path)
+	if _, ok := settings["hooks"]; ok {
+		t.Errorf("hooks key left behind: %v", settings["hooks"])
+	}
+	if settings["model"] != "opus" {
+		t.Errorf("model = %v, want opus", settings["model"])
+	}
+	allow := asSlice(asMap(settings["permissions"])["allow"])
+	if len(allow) != 1 || allow[0] != "Bash(ls *)" {
+		t.Errorf("permissions.allow = %v, want [Bash(ls *)]", allow)
+	}
+}
+
+// A no-op uninstall must not rewrite (and reformat) the file.
+func TestRemoveHooksNoOpDoesNotRewrite(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	// Deliberately not in MarshalIndent formatting: a rewrite would reformat.
+	initial := `{"model":"opus","hooks":{"PostToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"echo hi"}]}]}}`
+	writeTestFile(t, path, initial)
+
+	if got, err := removeHooks(path); err != nil || got != hookAbsent {
+		t.Fatalf("removeHooks = %v, %v; want hookAbsent, nil", got, err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != initial {
+		t.Errorf("file was rewritten despite no change:\n%s", data)
+	}
+}
+
+func TestRemoveHooksRejectsInvalidJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	writeTestFile(t, path, "{not json")
+	if _, err := removeHooks(path); err == nil {
+		t.Fatal("expected an error for invalid JSON, got nil")
+	}
+}
+
+// The real command end to end, against settings as `leash init` writes them.
+// (init itself can't produce them here: under `go test` the binary is
+// cli.test, not leash, so containsHook wouldn't own the result.)
+func TestUninstallCommand(t *testing.T) {
+	isolateHome(t)
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(wd, ".claude", "settings.json")
+	writeTestFile(t, path, `{"model":"opus","hooks":{
+		"PreToolUse":[{"matcher":"Bash|Write","hooks":[{"type":"command","command":"`+wantCommand+`"}]}],
+		"SessionStart":[{"matcher":"startup|resume|clear","hooks":[{"type":"command","command":"`+wantSessionCommand+`"}]}]}}`)
+
+	out := runLeash(t, "", "uninstall")
+	if !strings.Contains(out, "Removed the Leash hooks") {
+		t.Fatalf("uninstall output = %q, want a removal confirmation", out)
+	}
+
+	settings := readSettings(t, path)
+	if _, ok := settings["hooks"]; ok {
+		t.Fatalf("hooks left in settings after uninstall: %v", settings["hooks"])
+	}
+	if settings["model"] != "opus" {
+		t.Fatalf("model = %v, want opus preserved", settings["model"])
+	}
+
+	// Running it again is a friendly no-op.
+	if out := runLeash(t, "", "uninstall"); !strings.Contains(out, "No Leash hooks found") {
+		t.Fatalf("second uninstall output = %q, want the no-op message", out)
+	}
+}


### PR DESCRIPTION
Implements [ATR-38](https://linear.app/hoophq/issue/ATR-38/add-an-uninstall-command-for-the-hooks): for a tool positioned as "dev-owned, dev-editable, you can remove it", a clean exit door is a brand requirement.

## What changed

- **`leash uninstall [--global]`** (new `internal/cli/uninstall.go`): removes exactly the Leash hook entries from `./.claude/settings.json` / `~/.claude/settings.json`, preserving everything else.
- **Recognition reuses `containsHook`** — the same predicate init's converge uses — so a stale binary path, `--quiet`, or a hand-added `--rules` flag all still count as ours and get removed.
- **Containers that existed only for Leash are cleaned up**: an entry whose `hooks` list empties is dropped, an event whose entries empty is dropped, and the `hooks` key itself if nothing remains — so init → uninstall hands the file back as it was. Unrelated hooks sharing an event (or even sharing our entry's `hooks` array) survive.
- **No-op discipline**: nothing to remove means the file is not rewritten (preserving user formatting) and a missing file is never created. Malformed JSON is a hard error, same as init.
- **Naming**: `uninstall` over `init --remove` — it's the counterpart users look for in `--help`, and `remove` was already taken by pack removal. Docs record the distinction (`cli.md` section, README "and here's how you leave").

## Test plan

- Table-driven `TestRemoveHooks`: removes both hooks; missing file no-op; quiet/stale-path variants; hand-added flag; unrelated hook in the same event survives; unrelated command sharing our entry survives; a string merely *mentioning* the invocation is not ours.
- `TestRemoveHooksRoundTrip`: `installHooks` → `removeHooks` → settings byte-equal in content (`model`, `permissions` intact, no `hooks` residue).
- `TestRemoveHooksNoOpDoesNotRewrite` (formatting preserved), `TestRemoveHooksRejectsInvalidJSON`, end-to-end `TestUninstallCommand` through the real root command.
- Verified with the built binary: init → uninstall → `{}`, second uninstall prints the friendly no-op.
- `gofmt` / `go vet` / `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FubmMTgfqah1rKE4bLHZ9v