### PR TITLE
Add community scaffolding: CONTRIBUTING, SECURITY, issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,38 @@
+name: Bug report
+description: "Something else is broken — install, init, hooks, registry commands, output."
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened
+      description: Include the command you ran and any stderr — Leash logs its warnings there.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+    validations:
+      required: false
+  - type: input
+    id: version
+    attributes:
+      label: Leash version
+      description: "`leash version`"
+    validations:
+      required: true
+  - type: input
+    id: env
+    attributes:
+      label: Environment
+      description: OS + how you installed (brew / npm / release binary), and the agent if relevant (e.g. Claude Code x.y).
+      placeholder: "macOS 15, brew, Claude Code 2.1"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/hoophq/leash/security/advisories/new
+    about: "Exploitable issues in Leash itself — please report privately, not as a public issue. SECURITY.md explains what belongs here."

--- a/.github/ISSUE_TEMPLATE/detector-gap.yml
+++ b/.github/ISSUE_TEMPLATE/detector-gap.yml
@@ -1,0 +1,51 @@
+name: Detector gap (false negative)
+description: "A catastrophic command slipped through — Leash allowed something it should have caught."
+title: "[gap] "
+labels: ["detector-gap"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        First check the [threat model](https://github.com/hoophq/leash/blob/main/docs/threat-model.md):
+        some evasion paths (interpreter one-liners, write-then-run, obfuscation) are accepted
+        limits of shell-AST analysis, not gaps. If it's exploitable beyond a missed detection,
+        use [private reporting](https://github.com/hoophq/leash/security/advisories/new) instead.
+  - type: input
+    id: command
+    attributes:
+      label: The command that slipped through
+      placeholder: "find / -delete"
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: What it does, and why it's catastrophic
+      description: The blast radius — what would a developer lose if an agent ran this by mistake?
+    validations:
+      required: true
+  - type: dropdown
+    id: expected
+    attributes:
+      label: What Leash should have done
+      description: "The discipline: deny only what's almost never intentional; ask for anything a developer might mean."
+      options:
+        - ask
+        - deny
+        - warn
+    validations:
+      required: true
+  - type: checkboxes
+    id: threat-model
+    attributes:
+      label: Scope check
+      options:
+        - label: This isn't one of the accepted evasion paths in the threat model (or I'm arguing it shouldn't be one).
+          required: true
+  - type: input
+    id: version
+    attributes:
+      label: Leash version
+      description: "`leash version`"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/false-positive.yml
+++ b/.github/ISSUE_TEMPLATE/false-positive.yml
@@ -1,0 +1,56 @@
+name: False positive
+description: "Leash blocked or questioned an everyday command. The most valuable report we get — near-zero false positives is the whole product."
+title: "[FP] "
+labels: ["false-positive"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you — false-positive reports are exactly how the discipline holds.
+        Every fix ships with a test pinning your command as ALLOW forever.
+  - type: input
+    id: command
+    attributes:
+      label: The exact command (or file path / URL)
+      description: Verbatim, as the agent ran it. `leash check '<command>'` reproduces the verdict without an agent.
+      placeholder: "rm -rf ./build-cache"
+    validations:
+      required: true
+  - type: dropdown
+    id: decision
+    attributes:
+      label: What Leash decided
+      options:
+        - ask
+        - deny
+        - warn
+    validations:
+      required: true
+  - type: input
+    id: rule
+    attributes:
+      label: The rule that fired
+      description: Named in the 🐕 chat notice or the `leash check` card, e.g. `destructive-delete-outside-workspace`.
+    validations:
+      required: false
+  - type: textarea
+    id: why
+    attributes:
+      label: Why this is an everyday operation
+      description: What were you (or the agent) doing? Context decides where the matcher needs to narrow.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Leash version
+      description: "`leash version`"
+    validations:
+      required: true
+  - type: textarea
+    id: packs
+    attributes:
+      label: Active rulepacks beyond recommended
+      description: Installed packs (`ls ~/.leash/packs`), a project `.leash.yaml`, or a `--rules` file — paste the relevant rule if it's yours.
+    validations:
+      required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing to Leash
+
+Thanks for helping keep AI coding agents on a leash. Two kinds of
+contributions matter most here, and neither requires writing Go:
+
+- **A false-positive report** — Leash blocked or questioned an everyday
+  command. This is the single most valuable input the project gets: the
+  near-zero-false-positive discipline *is* the product.
+  [File one](https://github.com/hoophq/leash/issues/new?template=false-positive.yml)
+  with the exact command.
+- **A detector gap** — a catastrophe slipped through.
+  [File that too](https://github.com/hoophq/leash/issues/new?template=detector-gap.yml)
+  (check the [threat model](docs/threat-model.md) first: some evasion paths
+  are accepted limits, not gaps).
+
+## Building and testing
+
+Go 1.26, no runtime services. The Makefile has everything:
+
+```bash
+make build   # → ./dist/leash
+make test    # the gate — CI runs gofmt, go vet, go build, go test
+make vet
+make fmt
+```
+
+Try a rule without an agent:
+
+```bash
+leash check 'rm -rf ~'                # prints a DENY/ASK/WARN/ALLOW card
+echo '{"cwd":".","tool_name":"Bash","tool_input":{"command":"rm -rf ~"}}' \
+  | ./dist/leash hook claude-code    # exercise the hook directly
+```
+
+## The two conventions every detector PR must follow
+
+**1. Semantic, not substring.** Detection means adding a fact to the shell
+analyzer (`internal/analyzer/shell`) and a `Match` predicate in
+`internal/policy` — never a substring or regex denylist. A grep for `rm -rf`
+is dodged by `rm -fr`; a parsed AST is not. A rule's `regex` field is a
+fallback for patterns not yet modelled, never the primary mechanism.
+
+**2. Every detector ships a table-driven test that pins the catch AND the
+safe cases.** The safe cases are the point: `rm -rf node_modules`,
+`rm -rf *`, `git push --force-with-lease` must stay ALLOW, and the test is
+what keeps them that way. A detector PR without false-positive guards will
+be sent back for them. See any `*_test.go` under `internal/analyzer/shell`
+or `internal/policy` for the shape.
+
+When picking an effect, the discipline is: **`deny` only what is almost
+never intentional; `ask` for anything a developer might mean; leave the
+everyday untouched.** When in doubt, ask — a wrong `deny` costs the project
+more than a missed catch.
+
+## Other ways in
+
+- **A new agent** = a new adapter under `internal/adapter/<agent>/` that
+  maps the agent's tool calls ⇄ the neutral `Action`. The engine and every
+  rulepack come along for free. See
+  [architecture](docs/architecture.md#extending-leash).
+- **A rulepack** — no Go at all: packs are YAML, published by pull request.
+  The walkthrough is in [docs/registry.md](docs/registry.md#authoring-a-pack).
+  After editing a seed pack, recompute its `sha256` in `registry/index.yaml`
+  (the seed test fails CI on a stale one).
+- **Docs** — if something surprised you, the fix is probably a docs PR.
+
+## Public contracts
+
+The rulepack schema, the registry index format, and the hook envelope are
+frozen contracts ([what that means](docs/rules.md#schema-version--compatibility)).
+A PR that changes any of them needs a compatibility story, not just passing
+tests.
+
+## Security issues
+
+Don't open a public issue for a vulnerability — see [SECURITY.md](SECURITY.md)
+for the private channel and for what counts as a vulnerability in a
+deliberately fail-open tool.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Use GitHub's private vulnerability reporting:
+**[Security → Report a vulnerability](https://github.com/hoophq/leash/security/advisories/new)**.
+Please don't open a public issue for anything you believe is exploitable —
+give us a chance to ship a fix first. We'll acknowledge within a few days
+and keep you in the loop through the fix and disclosure.
+
+Only the latest release is supported with fixes.
+
+## What counts as a vulnerability here
+
+Leash is deliberately **fail-open** and **dev-owned** — the
+[threat model](docs/threat-model.md) spells out what it does and doesn't
+defend against. That line decides what belongs in the private channel:
+
+**Report privately (a vulnerability):**
+
+- Anything that makes Leash *itself* a risk: code execution or memory
+  unsafety triggered by parsing a malicious rulepack, registry index, or
+  hook payload.
+- The registry client escaping its boundaries — path traversal from an
+  index entry, a checksum-verification bypass, writes outside `~/.leash`.
+- The hook emitting an explicit allow decision, or otherwise *weakening*
+  the agent's own permission system (Leash must only ever tighten).
+- Secrets handled by Leash ending up somewhere they shouldn't.
+
+**Open a public issue instead (not a vulnerability):**
+
+- A dangerous command Leash didn't catch — that's a
+  [detector gap](https://github.com/hoophq/leash/issues/new?template=detector-gap.yml),
+  unless it's one of the evasion paths the threat model already accepts.
+- Fail-open behavior itself (a crash making Leash allow a call is by
+  design — though the *crash* is a bug we want fixed).
+- Anything that requires the developer to disable Leash on their own
+  machine. Dev-owned means that's always possible; it's not a bypass.
+
+When you're not sure which side of the line something falls on, use the
+private channel — worst case we'll ask you to file it publicly.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -97,8 +97,8 @@ mean emulating execution.
 `find / -delete` is **allowed** today. The semantic vocabulary grows one
 detector at a time, each shipped with catch-*and*-safe tests. An unmodeled
 destructive tool passes silently — when you find one,
-[file a detector-gap issue](https://github.com/hoophq/leash/issues); those
-reports are exactly how the vocabulary grows.
+[file a detector-gap issue](https://github.com/hoophq/leash/issues/new?template=detector-gap.yml);
+those reports are exactly how the vocabulary grows.
 
 **Disarming Leash itself.**
 The hooks live in dev-editable settings, so an agent with file-write access
@@ -127,10 +127,11 @@ a VM) and centrally enforced policy, with Leash still riding along for the
 mistakes.
 
 Found a bypass we don't list here? That's a
-[detector-gap report](https://github.com/hoophq/leash/issues) — or a
-[security report](https://github.com/hoophq/leash/security) if it's a flaw in
-Leash itself rather than a scope limit. Both are welcome; this page only
-stays honest if it stays current.
+[detector-gap report](https://github.com/hoophq/leash/issues/new?template=detector-gap.yml) —
+or a [private security report](https://github.com/hoophq/leash/security/advisories/new)
+if it's a flaw in Leash itself rather than a scope limit
+([SECURITY.md](../SECURITY.md) draws that line). Both are welcome; this page
+only stays honest if it stays current.
 
 ---
 


### PR DESCRIPTION
Implements [ATR-41](https://linear.app/hoophq/issue/ATR-41/add-community-scaffolding-contributing-security-issue-templates): the repo is public with zero contribution scaffolding, and the near-zero-false-positive thesis needs its feedback funnel.

## What changed

- **`CONTRIBUTING.md`** — leads with the two no-Go-required contributions (false-positive report, detector gap), then: `make test` as the gate, the semantic-not-substring convention, the every-detector-needs-catch-AND-safe-tests rule, the deny/ask effect discipline, new-agent adapters, rulepack publishing (links `docs/registry.md`), and a warning that the three public contracts frozen in #22 need a compatibility story to change.
- **`SECURITY.md`** — GitHub private vulnerability reporting as the channel, with the fail-open line drawn explicitly: what's a vulnerability (parse-triggered code execution, registry path traversal / checksum bypass, an explicit allow decision, secret mishandling) vs what's a public detector-gap issue (a missed detection) vs what's by design (fail-open, dev-side disabling).
- **Issue forms** (`.github/ISSUE_TEMPLATE/`): `false-positive.yml` — the important one — captures the exact command, the decision, the rule that fired, why it's everyday, version, and extra packs; `detector-gap.yml` includes a threat-model scope check so accepted evasion paths don't refill the tracker; `bug.yml` for everything else. `config.yml` disables blank issues and routes security reports to private reporting from the chooser.
- **Repo settings applied** (side effects, not in the diff): private vulnerability reporting enabled (verified `enabled: true`), labels `false-positive` and `detector-gap` created.
- `docs/threat-model.md` links upgraded to deep-link the new templates and SECURITY.md.

## Test plan

All four YAML forms validated with a YAML parser; `go test ./...` green; template/label names cross-checked (`labels:` in each form exists on the repo). Rendering is best confirmed on the GitHub UI after merge — the new-issue chooser should show the three forms plus the security contact link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FubmMTgfqah1rKE4bLHZ9v