### PR TITLE
Document Windows out at 1.0: honest refusal instead of a half-working hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ brew install hoophq/tap/leash
 npm install -g @hoophq/leash
 ```
 
+**Windows** isn't supported natively yet — the hook path hasn't been verified
+there, and a silently broken hook is worse than an honest no. **WSL works
+today** (Leash behaves exactly as on Linux inside it); native support is
+tracked in [#26](https://github.com/hoophq/leash/issues/26).
+
 ## Quickstart — Claude Code
 
 ```bash

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -30,6 +30,11 @@ Idempotent and non-destructive: it preserves existing settings (including a
 matcher you've customized) and won't add the hooks twice. Restart Claude Code
 (or start a new session) to activate them.
 
+On native Windows, `init` refuses with an honest message instead of
+installing a hook that was never verified there — use WSL (where Leash works
+exactly as on Linux) or follow
+[#26](https://github.com/hoophq/leash/issues/26).
+
 ## `leash uninstall`
 
 The exit door: removes the hooks `leash init` installed — and nothing else.

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -38,6 +39,9 @@ func newInitCommand() *cobra.Command {
 			"path and toggles --quiet on or off.",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := initSupportedOS(runtime.GOOS); err != nil {
+				return fail(cmd, err)
+			}
 			path, err := settingsPath(global)
 			if err != nil {
 				return fail(cmd, err)
@@ -68,6 +72,17 @@ func newInitCommand() *cobra.Command {
 	_ = cmd.Flags().MarkDeprecated("verbose",
 		"allowed-call notices are now the default; use --quiet to turn them off")
 	return cmd
+}
+
+// initSupportedOS refuses to install hooks where the hook path has never been
+// verified end to end — a silently broken hook is worse than an honest no.
+// Uninstall carries no such guard: removing hooks is always safe.
+func initSupportedOS(goos string) error {
+	if goos == "windows" {
+		return fmt.Errorf("native Windows isn't supported yet (the hook path is unverified there, and a silently broken hook is worse than an honest no) — " +
+			"run Leash inside WSL, where it works exactly as on Linux, or follow https://github.com/hoophq/leash/issues/26")
+	}
+	return nil
 }
 
 func settingsPath(global bool) (string, error) {

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -370,3 +370,18 @@ func TestContainsHook(t *testing.T) {
 		}
 	}
 }
+
+// Windows is documented out at 1.0: init must refuse honestly rather than
+// install a hook that was never verified there. See issue #26.
+func TestInitSupportedOS(t *testing.T) {
+	if err := initSupportedOS("windows"); err == nil {
+		t.Fatal("init on windows must refuse with an error")
+	} else if !strings.Contains(err.Error(), "WSL") {
+		t.Errorf("the refusal should point at WSL, got %q", err)
+	}
+	for _, goos := range []string{"darwin", "linux"} {
+		if err := initSupportedOS(goos); err != nil {
+			t.Errorf("initSupportedOS(%q) = %v, want nil", goos, err)
+		}
+	}
+}

--- a/npm/bin/leash.js
+++ b/npm/bin/leash.js
@@ -22,9 +22,15 @@ function binaryPath() {
 
 const bin = binaryPath();
 if (!bin) {
+  const windows =
+    process.platform === "win32"
+      ? `Native Windows isn't supported yet — run Leash inside WSL (works exactly as on Linux),\n` +
+        `or follow https://github.com/hoophq/leash/issues/26 for native support.\n`
+      : "";
   console.error(
     `leash: no prebuilt binary for ${process.platform}-${process.arch}.\n` +
       `Supported: darwin/linux on x64/arm64.\n` +
+      windows +
       `Install from source instead: go install github.com/hoophq/leash/cmd/leash@latest`
   );
   process.exit(1);


### PR DESCRIPTION
Implements [ATR-40](https://linear.app/hoophq/issue/ATR-40/decide-the-windows-story-support-it-or-document-it-out) with the **document-it-out** decision: a user on Windows gets an honest, immediate "not supported" everywhere they could hit Leash — never a silently broken hook.

## What changed

- **`leash init` refuses on `windows` GOOS** (`initSupportedOS` in `internal/cli/init.go`) with the reasoning, the WSL answer, and the tracking issue. `leash uninstall` deliberately keeps no guard — removing hooks is always safe.
- **npm wrapper** (`npm/bin/leash.js`): the existing no-prebuilt-binary error gains a win32-specific line pointing at WSL and #26 (it already exited honestly; now it says what to do instead).
- **README Install** and **docs/cli.md init** carry the Windows note: unverified hook path, WSL works today, native support tracked in [#26](https://github.com/hoophq/leash/issues/26).
- **Issue #26 created** as the commitment ledger for going native later: GoReleaser windows builds, win32 npm package, scoop/winget, end-to-end hook verification (backslashes in settings JSON, git-bash parsing), windows CI runner, and removing these carve-outs.

## Test plan

- `TestInitSupportedOS`: windows refuses (and the message points at WSL); darwin/linux pass.
- `gofmt` / `go vet` / `go test ./...` green; `node --check` on the wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FubmMTgfqah1rKE4bLHZ9v