### PR TITLE
Add the Alcatraz PII scan to the pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,4 +43,13 @@ jobs:
         run: go build ./...
 
       - name: Test
-        run: go test ./...
+        # Explicit bash => pipefail, so tee can't mask a test failure.
+        shell: bash
+        run: go test -v ./... 2>&1 | tee /tmp/test-output.log
+
+      - name: PII scan of test output
+        uses: hoophq/alcatraz-action@v1
+        with:
+          mode: files
+          paths: /tmp/test-output.log
+          comment: false # step summary only; keeps this workflow contents:read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
         run: go test -v ./... 2>&1 | tee /tmp/test-output.log
 
       - name: PII scan of test output
+        # Failing runs are the likeliest to leak PII, so scan even then.
+        if: always()
         uses: hoophq/alcatraz-action@v1
         with:
           mode: files

--- a/.github/workflows/pii.yml
+++ b/.github/workflows/pii.yml
@@ -1,0 +1,49 @@
+name: PII scan
+
+on:
+  pull_request:
+  issue_comment: # comments on issues AND pull requests
+    types: [created, edited]
+  issues:
+    types: [opened, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  # Scan the lines each PR adds; findings block the check until removed
+  # or allowlisted.
+  diff:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write # sticky report comment
+    # Cancel superseded runs on the same PR.
+    concurrency:
+      group: pii-diff-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Scan PR diff
+        uses: hoophq/alcatraz-action@v1
+
+  # Scan new/edited issue and comment bodies. Report only — a red X on a
+  # conversation event blocks nothing, so failing would just add noise.
+  comment:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write # replies on PR comments too
+    steps:
+      - name: Scan comment body
+        uses: hoophq/alcatraz-action@v1
+        with:
+          mode: comment
+          fail-on-findings: false

--- a/.github/workflows/pii.yml
+++ b/.github/workflows/pii.yml
@@ -2,6 +2,8 @@ name: PII scan
 
 on:
   pull_request:
+    # edited: rescan when the title/body change.
+    types: [opened, synchronize, reopened, edited]
   issue_comment: # comments on issues AND pull requests
     types: [created, edited]
   issues:
@@ -27,6 +29,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      # The title/body aren't part of the diff, so scan them as a file first
+      # (a diff finding must not mask this). The env indirection keeps the
+      # untrusted metadata out of shell parsing.
+      - name: Write PR title and body for scanning
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: printf '%s\n\n%s\n' "$PR_TITLE" "$PR_BODY" > /tmp/pr-metadata.txt
+
+      - name: Scan PR title and body
+        uses: hoophq/alcatraz-action@v1
+        with:
+          mode: files
+          paths: /tmp/pr-metadata.txt
+          comment: false # the diff scan owns the sticky report
 
       - name: Scan PR diff
         uses: hoophq/alcatraz-action@v1

--- a/.github/workflows/pii.yml
+++ b/.github/workflows/pii.yml
@@ -8,6 +8,10 @@ on:
     types: [created, edited]
   issues:
     types: [opened, edited]
+  pull_request_review_comment: # inline review comments
+    types: [created, edited]
+  pull_request_review: # review bodies
+    types: [submitted, edited]
 
 permissions:
   contents: read
@@ -49,8 +53,8 @@ jobs:
       - name: Scan PR diff
         uses: hoophq/alcatraz-action@v1
 
-  # Scan new/edited issue and comment bodies. Report only — a red X on a
-  # conversation event blocks nothing, so failing would just add noise.
+  # Scan new/edited issue, comment, and review bodies. Report only — a red X
+  # on a conversation event blocks nothing, so failing would just add noise.
   comment:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
@@ -60,8 +64,26 @@ jobs:
       issues: write
       pull-requests: write # replies on PR comments too
     steps:
+      # mode: comment reads .comment.body / .issue.body, which also covers
+      # inline review comments; review bodies live at .review.body, which the
+      # action can't see — scan those as a file below.
       - name: Scan comment body
+        if: github.event_name != 'pull_request_review'
         uses: hoophq/alcatraz-action@v1
         with:
           mode: comment
+          fail-on-findings: false
+
+      - name: Write review body for scanning
+        if: github.event_name == 'pull_request_review'
+        env:
+          REVIEW_BODY: ${{ github.event.review.body }}
+        run: printf '%s\n' "$REVIEW_BODY" > /tmp/review-body.txt
+
+      - name: Scan review body
+        if: github.event_name == 'pull_request_review'
+        uses: hoophq/alcatraz-action@v1
+        with:
+          mode: files
+          paths: /tmp/review-body.txt
           fail-on-findings: false


### PR DESCRIPTION
Dogfoods [hoophq/alcatraz-action](https://github.com/hoophq/alcatraz-action) (v1) across all three of its modes.

## What's in here

**New `pii.yml` workflow** — two jobs with least-privilege job-level permissions:
- `diff` on every `pull_request`: scans the lines the PR adds, annotates them, posts the sticky masked report, and fails the check until findings are removed or allowlisted. Superseded runs on the same PR are cancelled.
- `comment` on `issue_comment` (created/edited) + `issues` (opened/edited): scans the body and replies with a masked report. `fail-on-findings: false` here per the action's README — a red X on a conversation event gates nothing.

**`ci.yml`** — the test step tees `go test -v` output to `/tmp/test-output.log`, then a `mode: files` scan checks it for PII emitted at runtime:
- `shell: bash` is declared explicitly so pipefail keeps `tee` from masking a test failure (the default `run:` shell has no pipefail).
- `comment: false` on the scan keeps the workflow at `contents: read`; findings still fail the job and show in the step summary.

## Notes

- Pinned `@v1`, matching the repo's major-tag pinning style.
- If the diff scan false-positives on fixture-heavy PRs, `allowlist-file` / `exclude` are the tuning knobs (lockfiles, `go.sum`, and vendored code are already excluded by default).
- This PR is itself the first live exercise of the diff scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VwqbfvgNLSte54ivycyXW2