### PR TITLE
Replace the Claude Code session banner with a status line

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,8 @@ central audit, and approval workflows out of scope.
   semantic facts (recursive-delete + target class, force-push, history-rewrite,
   net→shell pipe). **This is the differentiator** — see Conventions.
 - `internal/adapter/<agent>/` — translate one agent's tool call ⇄ neutral `Action`.
-  `claudecode` (Claude Code PreToolUse + the SessionStart banner) came first;
+  `claudecode` (Claude Code PreToolUse + the statusLine session proof, with the
+  SessionStart banner as fallback when another status line owns the slot) came first;
   `codex` speaks Codex's Claude-compatible hook envelope with its own tool
   vocabulary (`Bash`, `apply_patch` — expanded to one file_write per touched
   file, most severe verdict wins); `opencode` has no hook protocol at all — a

--- a/README.md
+++ b/README.md
@@ -102,11 +102,13 @@ tracked in [#26](https://github.com/hoophq/fence/issues/26).
 fence init --global   # add the Fence hooks to .claude/settings.json, for every project
 ```
 
-Start a Claude Code session and Fence is live — a banner in the chat confirms
-it (`🚧 Fence is guarding this session…`). Ask the agent for something
-reckless — it gets stopped, or asked to confirm, with a `🚧` notice in the chat
-saying which rule fired. Allowed calls get a notice too, so you can see Fence
-watching; `fence init --quiet` turns those off.
+Start a Claude Code session and Fence is live — a status line at the bottom
+of the UI confirms it, for the whole session (`🚧 Fence v1.2.0 · 1 pack ·
+19 rules`). Already have a status line? Fence won't touch it — it announces
+itself with a chat banner instead. Ask the agent for something reckless — it
+gets stopped, or asked to confirm, with a `🚧` notice in the chat saying which
+rule fired. Allowed calls get a notice too, so you can see Fence watching;
+`fence init --quiet` turns those off.
 
 ```bash
 claude

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,9 +9,13 @@ flag ([rulepack reference](rules.md)).
 ## `fence init`
 
 Wire Fence into an agent: it adds a `PreToolUse` hook to the agent's settings
-so every tool call is inspected before it runs, and a `SessionStart` hook that
-shows a banner when a session begins — proof Fence is active, with the pack
-and rule counts.
+so every tool call is inspected before it runs, plus visible proof Fence is
+active, with the pack and rule counts. For Claude Code that proof is a
+persistent **status line** (`🚧 Fence v1.2.0 · 1 pack · 19 rules`); if you
+already have a status line configured — in this file or a scope that
+interacts with it — Fence leaves it alone and installs a `SessionStart` chat
+banner instead (init tells you, and how to add Fence to your own status line).
+Codex gets the `SessionStart` banner.
 
 ```bash
 fence init                     # Claude Code, project — ./.claude/settings.json
@@ -50,11 +54,12 @@ exactly as on Linux) or follow
 
 ## `fence uninstall`
 
-The exit door: removes the hooks `fence init` installed — and nothing else.
-Unrelated hooks, customized matchers on other entries, and every other
-setting in the file stay exactly as they were; containers that existed only
-to hold the Fence hooks are cleaned up rather than left empty. Running it
-when nothing is installed is a friendly no-op.
+The exit door: removes everything `fence init` installed — the hooks and
+Fence's status line — and nothing else. Unrelated hooks, a status line that
+isn't Fence's, customized matchers on other entries, and every other setting
+in the file stay exactly as they were; containers that existed only to hold
+the Fence hooks are cleaned up rather than left empty. Running it when
+nothing is installed is a friendly no-op.
 
 ```bash
 fence uninstall                    # Claude Code, project settings
@@ -183,15 +188,25 @@ Deny/ask/warn responses carry a `systemMessage` so the decision is visible in
 the chat. Allowed calls get a notice too (unless `--quiet`) — but never an
 explicit allow decision, so your own permission settings still apply.
 
+`fence hook claude-code statusline` is the `statusLine` entrypoint `fence
+init` wires in: it prints one plain-text line — `🚧 Fence v1.2.0 · 1 pack ·
+19 rules` — that Claude Code renders at the bottom of the UI for the whole
+session. To keep your own status line and still see Fence in it, have your
+statusline command append this one's output.
+
 `fence hook claude-code session-start` is the `SessionStart` entrypoint: it
-prints the "guarding this session" banner (wired in by `fence init` as well).
-If an installed pack or `.fence.yaml` fails to load, the banner says so —
-`⚠️ 1 rulepack failed to load` — instead of silently showing a lower count;
-run any fence command in a terminal to see the load warnings.
+prints the "guarding this session" chat banner. It's what init installs when
+another status line already occupies the slot, and settings from banner-era
+installs keep working — re-running `fence init` migrates them.
+
+If an installed pack or `.fence.yaml` fails to load, the status line and the
+banner say so — `⚠️ 1 rulepack failed to load` — instead of silently showing
+a lower count; run any fence command in a terminal to see the load warnings.
 
 Every variant always exits 0 and **fails open**: if the input can't be
 understood or the rules can't load, the tool call proceeds as if Fence weren't
-there — and the session banner says so instead of pretending you're covered.
+there — and the status line (or banner) says so instead of pretending you're
+covered.
 
 ### The `claude-code` envelope (frozen at 1.0)
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -105,13 +105,13 @@ those reports are exactly how the vocabulary grows.
 The hooks live in dev-editable settings, so an agent with file-write access
 can edit `.claude/settings.json` (an **allowed** write today), and deleting
 the binary or `~/.fence` is at worst an *ask*. Two backstops: the agent's own
-permission system still governs those writes, and the SessionStart banner
-makes absence visible — a session that starts without
-`🚧 Fence is guarding this session` isn't guarded. Check for the barrier.
+permission system still governs those writes, and the `🚧 Fence` status line
+(or, where it can't live, the SessionStart banner) makes absence visible — a
+session without the barrier on screen isn't guarded. Check for the barrier.
 
 **Fail-open, stated plainly.**
 If Fence crashes, can't parse its input, or can't load its rules, the tool
-call proceeds and the banner says so. A guardrail that can brick your agent
+call proceeds and the status line says so. A guardrail that can brick your agent
 gets removed within the hour; failing open is the survivable default for a
 dev-owned tool. The cost is real: anything that makes Fence error out
 disarms it. That trade is deliberate.

--- a/internal/adapter/claudecode/claudecode.go
+++ b/internal/adapter/claudecode/claudecode.go
@@ -149,16 +149,13 @@ func WriteDecision(w io.Writer, d policy.Decision, quiet bool) error {
 // session runs with less than the configured protection. It carries no
 // permission decision and adds nothing to the model's context (plain stdout on
 // SessionStart would).
+//
+// The status line replaced this banner as what `fence init` wires in, but the
+// entrypoint stays: settings written by older installs — and by init when
+// another status line already owns the slot — still invoke it.
 func WriteSessionStart(w io.Writer, version string, packs, rules, failed int) error {
-	name := "Fence"
-	if version != "" {
-		if version[0] >= '0' && version[0] <= '9' {
-			version = "v" + version
-		}
-		name += " " + version
-	}
 	msg := fmt.Sprintf("🚧 %s is guarding this session (%s, %s)",
-		name, plural(packs, "pack"), plural(rules, "rule"))
+		displayName(version), plural(packs, "pack"), plural(rules, "rule"))
 	if failed > 0 {
 		msg += fmt.Sprintf(" — ⚠️ %s failed to load", plural(failed, "rulepack"))
 	}
@@ -172,6 +169,42 @@ func WriteSessionStartDegraded(w io.Writer) error {
 	return emit(w, hookOutput{
 		SystemMessage: "🚧 Fence could not load its rules — tool calls in this session are NOT being screened (see stderr in the transcript)",
 	})
+}
+
+// WriteStatusLine emits the Fence status line: persistent proof the session
+// is guarded, with the active pack and rule counts — and, when ambient
+// rulepacks failed to load, that protection is thinner than configured.
+// Claude Code renders a statusLine command's stdout directly, so this is
+// plain text, not the hook JSON envelope.
+func WriteStatusLine(w io.Writer, version string, packs, rules, failed int) error {
+	msg := fmt.Sprintf("🚧 %s · %s · %s",
+		displayName(version), plural(packs, "pack"), plural(rules, "rule"))
+	if failed > 0 {
+		msg += fmt.Sprintf(" — ⚠️ %s failed to load", plural(failed, "rulepack"))
+	}
+	_, err := fmt.Fprintln(w, msg)
+	return err
+}
+
+// WriteStatusLineDegraded emits the status line for the case where the rules
+// could not be loaded: the guardrail fails open, so the honest line is that
+// this session is not being screened.
+func WriteStatusLineDegraded(w io.Writer) error {
+	_, err := fmt.Fprintln(w, "🚧 Fence — ⚠️ rules failed to load, tool calls NOT screened")
+	return err
+}
+
+// displayName renders the product name with its version when known, giving
+// bare release numbers (as -ldflags injects them) their conventional v prefix.
+func displayName(version string) string {
+	name := "Fence"
+	if version != "" {
+		if version[0] >= '0' && version[0] <= '9' {
+			version = "v" + version
+		}
+		name += " " + version
+	}
+	return name
 }
 
 func emit(w io.Writer, out hookOutput) error {

--- a/internal/adapter/claudecode/claudecode_test.go
+++ b/internal/adapter/claudecode/claudecode_test.go
@@ -289,3 +289,83 @@ func TestWriteSessionStartDegraded(t *testing.T) {
 		t.Fatalf("degraded banner must not include hookSpecificOutput: %s", buf.String())
 	}
 }
+
+func TestWriteStatusLine(t *testing.T) {
+	cases := []struct {
+		name    string
+		version string
+		packs   int
+		rules   int
+		failed  int
+		want    []string
+	}{
+		{
+			name:    "release version gets a v prefix",
+			version: "0.0.4", packs: 3, rules: 42,
+			want: []string{"🚧 Fence v0.0.4", "3 packs", "42 rules"},
+		},
+		{
+			name:    "git-describe version is kept as-is",
+			version: "v0.0.4-2-gabc1234", packs: 2, rules: 40,
+			want: []string{"Fence v0.0.4-2-gabc1234"},
+		},
+		{
+			name:    "dev build and singular counts",
+			version: "dev", packs: 1, rules: 1,
+			want: []string{"Fence dev", "1 pack ·", "1 rule"},
+		},
+		{
+			name:  "no version at all",
+			packs: 1, rules: 34,
+			want: []string{"🚧 Fence · 1 pack · 34 rules"},
+		},
+		{
+			name:    "a failed ambient pack is called out",
+			version: "0.0.4", packs: 1, rules: 19, failed: 1,
+			want: []string{"⚠️ 1 rulepack failed to load"},
+		},
+		{
+			name:    "several failed packs pluralize",
+			version: "0.0.4", packs: 1, rules: 19, failed: 2,
+			want: []string{"2 rulepacks failed to load"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := WriteStatusLine(&buf, tc.version, tc.packs, tc.rules, tc.failed); err != nil {
+				t.Fatalf("WriteStatusLine: %v", err)
+			}
+			out := buf.String()
+			for _, part := range tc.want {
+				if !strings.Contains(out, part) {
+					t.Errorf("status line = %q, want it to contain %q", out, part)
+				}
+			}
+			// The statusLine protocol is rendered stdout: one plain-text line,
+			// not the hook JSON envelope.
+			if strings.Contains(out, "{") || strings.Count(out, "\n") != 1 || !strings.HasSuffix(out, "\n") {
+				t.Errorf("status line must be one plain-text line, got %q", out)
+			}
+			// A clean load must not hedge the line.
+			if tc.failed == 0 && strings.Contains(out, "failed to load") {
+				t.Errorf("clean status line mentions failures: %q", out)
+			}
+		})
+	}
+}
+
+func TestWriteStatusLineDegraded(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteStatusLineDegraded(&buf); err != nil {
+		t.Fatalf("WriteStatusLineDegraded: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "NOT screened") {
+		t.Errorf("degraded status line must say the session is unscreened, got %q", out)
+	}
+	if strings.Contains(out, "{") {
+		t.Errorf("degraded status line must be plain text, got %q", out)
+	}
+}

--- a/internal/cli/hook.go
+++ b/internal/cli/hook.go
@@ -52,6 +52,7 @@ func newClaudeCodeHookCommand(version string) *cobra.Command {
 	cmd.Flags().Bool("verbose", true, "")
 	_ = cmd.Flags().MarkHidden("verbose")
 	cmd.AddCommand(newSessionStartHookCommand(version))
+	cmd.AddCommand(newStatusLineHookCommand(version))
 	return cmd
 }
 
@@ -61,12 +62,32 @@ func newSessionStartHookCommand(version string) *cobra.Command {
 		Short: "Claude Code SessionStart hook entrypoint (prints the session banner)",
 		Long: "Writes a SessionStart response whose systemMessage tells the user this\n" +
 			"session is guarded by Fence, with the active pack and rule counts.\n" +
-			"`fence init` wires it in alongside the PreToolUse hook.",
+			"The status line has replaced it as what `fence init` wires in, but the\n" +
+			"entrypoint stays: settings written by older installs — and by init when\n" +
+			"another status line already occupies the slot — still invoke it.",
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runSessionStartHook(cmd.OutOrStdout(), cmd.ErrOrStderr(), version)
+		},
+	}
+}
+
+func newStatusLineHookCommand(version string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "statusline",
+		Short: "Claude Code statusLine entrypoint (prints the Fence status line)",
+		Long: "Writes one plain-text line for Claude Code's statusLine setting:\n" +
+			"persistent proof this session is guarded by Fence, with the active pack\n" +
+			"and rule counts. `fence init` wires it in when no other status line is\n" +
+			"configured; to combine it with your own, have your statusline command\n" +
+			"append the output of `fence hook claude-code statusline`.",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runStatusLineHook(cmd.OutOrStdout(), cmd.ErrOrStderr(), version)
 		},
 	}
 }
@@ -216,10 +237,11 @@ func effectRank(e policy.Effect) int {
 	}
 }
 
-// runAgentSessionStartHook is the shared session-banner flow, parameterized
-// by one adapter's banner writers. It always returns nil (exit 0): a banner
-// must never block a session from starting. It deliberately does not read
-// stdin — blocking on an agent that keeps the pipe open would do exactly that.
+// runAgentSessionStartHook is the shared session-status flow — the session
+// banners and the Claude Code status line, parameterized by one adapter's
+// writers. It always returns nil (exit 0): session status must never block a
+// session from starting. It deliberately does not read stdin — blocking on an
+// agent that keeps the pipe open would do exactly that.
 func runAgentSessionStartHook(out, errw io.Writer, version string,
 	writeBanner func(w io.Writer, version string, packs, rules, failed int) error,
 	writeDegraded func(io.Writer) error,
@@ -228,12 +250,12 @@ func runAgentSessionStartHook(out, errw io.Writer, version string,
 	if err != nil {
 		fmt.Fprintf(errw, "fence: failed to load rules: %v\n", err)
 		if err := writeDegraded(out); err != nil {
-			fmt.Fprintf(errw, "fence: could not write session banner: %v\n", err)
+			fmt.Fprintf(errw, "fence: could not write session status: %v\n", err)
 		}
 		return nil
 	}
 	if err := writeBanner(out, version, engine.PackCount(), engine.RuleCount(), failed); err != nil {
-		fmt.Fprintf(errw, "fence: could not write session banner: %v\n", err)
+		fmt.Fprintf(errw, "fence: could not write session status: %v\n", err)
 	}
 	return nil
 }
@@ -241,6 +263,11 @@ func runAgentSessionStartHook(out, errw io.Writer, version string,
 func runSessionStartHook(out, errw io.Writer, version string) error {
 	return runAgentSessionStartHook(out, errw, version,
 		claudecode.WriteSessionStart, claudecode.WriteSessionStartDegraded)
+}
+
+func runStatusLineHook(out, errw io.Writer, version string) error {
+	return runAgentSessionStartHook(out, errw, version,
+		claudecode.WriteStatusLine, claudecode.WriteStatusLineDegraded)
 }
 
 func runCodexSessionStartHook(out, errw io.Writer, version string) error {

--- a/internal/cli/hook_test.go
+++ b/internal/cli/hook_test.go
@@ -129,3 +129,41 @@ func TestHookSessionStartReportsFailedPack(t *testing.T) {
 		t.Errorf("banner should still count the recommended pack:\n%s", out)
 	}
 }
+
+func TestHookStatusLine(t *testing.T) {
+	isolateHome(t)
+	out := runFence(t, "", "hook", "claude-code", "statusline")
+	for _, want := range []string{"🚧 Fence v1.2.3", "1 pack"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("status line missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "failed to load") {
+		t.Errorf("clean status line mentions failures:\n%s", out)
+	}
+	// The statusLine protocol renders stdout as-is: plain text, no JSON.
+	if strings.Contains(out, "{") {
+		t.Fatalf("status line must be plain text, not a JSON envelope:\n%s", out)
+	}
+}
+
+func TestHookStatusLineReportsFailedPack(t *testing.T) {
+	home := isolateHome(t)
+	packs := filepath.Join(home, ".fence", "packs")
+	if err := os.MkdirAll(packs, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(packs, "broken.yaml"),
+		[]byte("rules:\n  - id: x\n    effect: nope\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out := runFence(t, "", "hook", "claude-code", "statusline")
+	if !strings.Contains(out, "1 rulepack failed to load") {
+		t.Errorf("status line does not report the broken pack:\n%s", out)
+	}
+	// The recommended pack still protects underneath.
+	if !strings.Contains(out, "1 pack ·") {
+		t.Errorf("status line should still count the recommended pack:\n%s", out)
+	}
+}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -39,6 +39,7 @@ type hookAgent struct {
 	sessionMatcher string
 	trustNote      string // printed after install (Codex's hook-trust step)
 	plugin         bool   // installs a generated plugin file instead of JSON hook entries
+	statusLine     bool   // announces via a statusLine entry, banner hook as fallback
 }
 
 var hookAgents = []hookAgent{
@@ -50,6 +51,7 @@ var hookAgents = []hookAgent{
 		invocation:     "fence hook claude-code",
 		preMatcher:     toolMatcher,
 		sessionMatcher: sessionStartMatcher,
+		statusLine:     true,
 	},
 	{
 		name:           "codex",
@@ -93,16 +95,19 @@ func newInitCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init [agent]",
 		Short: "Install the Fence hooks into an agent's settings",
-		Long: "Adds two hooks to an agent's settings: a PreToolUse hook so Fence\n" +
-			"inspects each tool call, and a SessionStart hook that shows a banner\n" +
-			"confirming the session is guarded. The agent is claude-code (default),\n" +
-			"codex, or opencode. By default it writes the project settings (./.claude,\n" +
-			"./.codex or ./.opencode); use --global for the user-level file under ~.\n" +
+		Long: "Adds Fence to an agent's settings: a PreToolUse hook so Fence inspects\n" +
+			"each tool call, plus visible proof the session is guarded — a status\n" +
+			"line for Claude Code (or, when another status line is already\n" +
+			"configured, a SessionStart chat banner), a SessionStart banner for\n" +
+			"Codex. The agent is claude-code (default), codex, or opencode. By\n" +
+			"default it writes the project settings (./.claude, ./.codex or\n" +
+			"./.opencode); use --global for the user-level file under ~.\n" +
 			"OpenCode has no hooks file, so init installs a small plugin\n" +
 			"(plugins/fence.js) that does the same job.\n\n" +
 			"The change is idempotent and preserves any existing settings. Re-running\n" +
 			"init always converges the hook commands, so it also heals a stale binary\n" +
-			"path and toggles --quiet on or off.",
+			"path, migrates a banner-era install to the status line, and toggles\n" +
+			"--quiet on or off.",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := initSupportedOS(runtime.GOOS); err != nil {
@@ -112,13 +117,19 @@ func newInitCommand() *cobra.Command {
 			if err != nil {
 				return fail(cmd, err)
 			}
-			var path string
+			var path, note string
 			var result hookInstallResult
-			if agent.plugin {
+			switch {
+			case agent.plugin:
 				if path, err = opencodePluginPath(global); err == nil {
 					result, err = installOpencodePlugin(path, quiet)
 				}
-			} else {
+			case agent.statusLine:
+				if path, err = settingsPath(agent, global); err == nil {
+					result, note, err = installStatusLineHooks(path, agent,
+						desiredHooks(agent, quiet), hookInvocation(agent)+" statusline", global)
+				}
+			default:
 				if path, err = settingsPath(agent, global); err == nil {
 					result, err = installHooks(path, desiredHooks(agent, quiet))
 				}
@@ -139,6 +150,9 @@ func newInitCommand() *cobra.Command {
 				fmt.Fprintf(cmd.OutOrStdout(), "Restart %s (or start a new session) to pick up the change.\n", agent.display)
 			default:
 				fmt.Fprintf(cmd.OutOrStdout(), "Fence %s already present in %s\n", what, path)
+			}
+			if note != "" {
+				fmt.Fprintf(cmd.OutOrStdout(), "%s\n", note)
 			}
 			if agent.trustNote != "" && result != hookUnchanged {
 				fmt.Fprintf(cmd.OutOrStdout(), "%s\n", agent.trustNote)
@@ -233,23 +247,60 @@ const (
 	hookInstalled
 )
 
+// loadSettings reads the settings JSON at path into a generic map. A missing
+// or empty file yields an empty map: converging into nothing is how a fresh
+// install starts.
+func loadSettings(path string) (map[string]any, error) {
+	settings := map[string]any{}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return settings, nil
+		}
+		return nil, err
+	}
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, &settings); err != nil {
+			return nil, fmt.Errorf("%s is not valid JSON: %w", path, err)
+		}
+	}
+	return settings, nil
+}
+
+// saveSettings writes the settings map back to path, creating the directory
+// if necessary.
+func saveSettings(path string, settings map[string]any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	out, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return err
+	}
+	out = append(out, '\n')
+	return os.WriteFile(path, out, 0o644)
+}
+
 // installHooks merges the desired hook entries into the settings file at path,
 // creating it if necessary. An existing fence hook whose command differs —
 // e.g. a stale binary path left by a previous install, or a quiet toggle —
 // is updated in place, so re-running `fence init` always converges on working
 // hooks.
 func installHooks(path string, specs []hookSpec) (hookInstallResult, error) {
-	settings := map[string]any{}
-	if data, err := os.ReadFile(path); err == nil {
-		if len(data) > 0 {
-			if err := json.Unmarshal(data, &settings); err != nil {
-				return hookUnchanged, fmt.Errorf("%s is not valid JSON: %w", path, err)
-			}
-		}
-	} else if !os.IsNotExist(err) {
+	settings, err := loadSettings(path)
+	if err != nil {
 		return hookUnchanged, err
 	}
+	result := convergeHooks(settings, specs)
+	if result == hookUnchanged {
+		return hookUnchanged, nil
+	}
+	return result, saveSettings(path, settings)
+}
 
+// convergeHooks merges the desired hook entries into the in-memory settings
+// and reports the most newsworthy change it made.
+func convergeHooks(settings map[string]any, specs []hookSpec) hookInstallResult {
 	hooks := asMap(settings["hooks"])
 
 	result := hookUnchanged
@@ -282,31 +333,18 @@ func installHooks(path string, specs []hookSpec) (hookInstallResult, error) {
 		}
 	}
 
-	if result == hookUnchanged {
-		return hookUnchanged, nil
+	if result != hookUnchanged {
+		settings["hooks"] = hooks
 	}
-	settings["hooks"] = hooks
-
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return hookUnchanged, err
-	}
-	out, err := json.MarshalIndent(settings, "", "  ")
-	if err != nil {
-		return hookUnchanged, err
-	}
-	out = append(out, '\n')
-	if err := os.WriteFile(path, out, 0o644); err != nil {
-		return hookUnchanged, err
-	}
-	return result, nil
+	return result
 }
 
 // convergeCommand rewrites an existing Fence hook command to the desired
 // invocation while keeping any trailing tokens init does not manage (a
 // hand-added --rules, say): the user put them there, and dropping them would
-// silently weaken their setup. The tokens init owns — the session-start
-// subcommand, --quiet, and the legacy --verbose (now the default, so the
-// token is dropped) — are regenerated from the desired command.
+// silently weaken their setup. The tokens init owns — the session-start and
+// statusline subcommands, --quiet, and the legacy --verbose (now the default,
+// so the token is dropped) — are regenerated from the desired command.
 func convergeCommand(existing, desired, invocation string) string {
 	_, rest, found := strings.Cut(existing, invocation)
 	if !found {
@@ -314,7 +352,7 @@ func convergeCommand(existing, desired, invocation string) string {
 	}
 	var extra []string
 	for tok := range strings.FieldsSeq(rest) {
-		if tok == "session-start" || tok == "--quiet" || tok == "--verbose" {
+		if tok == "session-start" || tok == "statusline" || tok == "--quiet" || tok == "--verbose" {
 			continue
 		}
 		extra = append(extra, tok)

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -359,6 +359,8 @@ func TestContainsHook(t *testing.T) {
 		{"/Users/dev/go/bin/fence hook claude-code", true},
 		{"fence hook claude-code session-start", true},
 		{"/opt/homebrew/bin/fence hook claude-code session-start", true},
+		{"fence hook claude-code statusline", true},
+		{"/opt/homebrew/bin/fence hook claude-code statusline", true},
 		{"/opt/homebrew/bin/fence hook claude-code --quiet", true},
 		{"/opt/homebrew/bin/fence hook claude-code --verbose", true}, // legacy installs
 		{"fence hook claude-codex", false},

--- a/internal/cli/statusline.go
+++ b/internal/cli/statusline.go
@@ -90,7 +90,11 @@ func statusLineTaken(path string, settings map[string]any, global bool, invocati
 		}
 		otherSettings, err := loadSettings(other)
 		if err != nil {
-			continue // an unreadable scope shouldn't block the install
+			// An unreadable scope shouldn't block the install, but say so:
+			// a status line hiding in a file we couldn't read would get
+			// shadowed without warning.
+			fmt.Fprintf(os.Stderr, "fence: checking %s for a status line: %v (assuming none)\n", other, err)
+			continue
 		}
 		if foreignStatusLine(otherSettings, invocation) {
 			return other, true

--- a/internal/cli/statusline.go
+++ b/internal/cli/statusline.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// installStatusLineHooks converges the settings of an agent that announces
+// Fence through a status line (Claude Code): the PreToolUse spec always, plus
+// Fence's statusLine entry — running slCommand — when the slot is free or
+// already ours, removing the legacy SessionStart banner hook the status line
+// replaces. When another status line is configured, in this file or a scope
+// that interacts with it, Fence leaves it untouched and falls back to the
+// SessionStart banner spec; the returned note tells the user why.
+func installStatusLineHooks(path string, agent hookAgent, specs []hookSpec, slCommand string, global bool) (hookInstallResult, string, error) {
+	settings, err := loadSettings(path)
+	if err != nil {
+		return hookUnchanged, "", err
+	}
+
+	pre, session := specs[0], specs[1]
+
+	if takenAt, taken := statusLineTaken(path, settings, global, agent.invocation); taken {
+		result := convergeHooks(settings, []hookSpec{pre, session})
+		note := fmt.Sprintf("A status line is already configured (%s) — left untouched; the session banner announces Fence instead.\n"+
+			"To show Fence there too, have your statusline command append the output of `%s statusline`.",
+			takenAt, agent.invocation)
+		if result == hookUnchanged {
+			return hookUnchanged, note, nil
+		}
+		return result, note, saveSettings(path, settings)
+	}
+
+	result := convergeHooks(settings, []hookSpec{pre})
+	result = max(result, convergeStatusLine(settings, agent.invocation, slCommand))
+	// The status line replaces the banner-era SessionStart hook: converge
+	// installs from before it existed by removing theirs. The hooks map can't
+	// empty out here — the PreToolUse entry was just converged into it.
+	if removeEventHooks(asMap(settings["hooks"]), "SessionStart", agent.invocation) {
+		result = max(result, hookUpdated)
+	}
+
+	if result == hookUnchanged {
+		return hookUnchanged, "", nil
+	}
+	return result, "", saveSettings(path, settings)
+}
+
+// convergeStatusLine points the settings' statusLine entry at command.
+// Fence's own entry is converged in place — keys the user added to it
+// (padding, say) survive, and unmanaged trailing tokens ride along exactly as
+// for hook commands. The caller has already established the slot is not
+// someone else's.
+func convergeStatusLine(settings map[string]any, invocation, command string) hookInstallResult {
+	sl := asMap(settings["statusLine"])
+	if existing, ok := sl["command"].(string); ok && containsHook(existing, invocation) {
+		want := convergeCommand(existing, command, invocation)
+		if existing == want {
+			return hookUnchanged
+		}
+		sl["command"] = want
+		return hookUpdated
+	}
+	settings["statusLine"] = map[string]any{"type": "command", "command": command}
+	return hookInstalled
+}
+
+// statusLineTaken reports whether a status line that is not Fence's already
+// governs sessions this install would cover, and where. Beyond the target
+// settings themselves, a project install checks the scopes it interacts with:
+// the user-level settings a project statusLine would silently shadow, and the
+// project-local file that would shadow ours. Occupying the slot in either
+// case clobbers the user's setup in effect, if not in bytes.
+func statusLineTaken(path string, settings map[string]any, global bool, invocation string) (string, bool) {
+	if foreignStatusLine(settings, invocation) {
+		return path, true
+	}
+	if global {
+		return "", false
+	}
+	var others []string
+	if home, err := os.UserHomeDir(); err == nil {
+		others = append(others, filepath.Join(home, ".claude", "settings.json"))
+	}
+	others = append(others, filepath.Join(filepath.Dir(path), "settings.local.json"))
+	for _, other := range others {
+		if other == path {
+			continue
+		}
+		otherSettings, err := loadSettings(other)
+		if err != nil {
+			continue // an unreadable scope shouldn't block the install
+		}
+		if foreignStatusLine(otherSettings, invocation) {
+			return other, true
+		}
+	}
+	return "", false
+}
+
+// foreignStatusLine reports whether settings carry a status line that is not
+// Fence's own. Any statusLine shape not positively recognized as ours counts:
+// the slot belongs to the user.
+func foreignStatusLine(settings map[string]any, invocation string) bool {
+	sl, present := settings["statusLine"]
+	if !present {
+		return false
+	}
+	cmd, ok := asMap(sl)["command"].(string)
+	return !ok || !containsHook(cmd, invocation)
+}

--- a/internal/cli/statusline.go
+++ b/internal/cli/statusline.go
@@ -23,6 +23,13 @@ func installStatusLineHooks(path string, agent hookAgent, specs []hookSpec, slCo
 
 	if takenAt, taken := statusLineTaken(path, settings, global, agent.invocation); taken {
 		result := convergeHooks(settings, []hookSpec{pre, session})
+		// A Fence statusLine left in the target from an earlier install would
+		// keep shadowing the user's — drop it. Only Fence's own entry can
+		// match: a foreign one in the target is never containsHook-owned.
+		if cmd, ok := asMap(settings["statusLine"])["command"].(string); ok && containsHook(cmd, agent.invocation) {
+			delete(settings, "statusLine")
+			result = max(result, hookUpdated)
+		}
 		note := fmt.Sprintf("A status line is already configured (%s) — left untouched; the session banner announces Fence instead.\n"+
 			"To show Fence there too, have your statusline command append the output of `%s statusline`.",
 			takenAt, agent.invocation)

--- a/internal/cli/statusline_test.go
+++ b/internal/cli/statusline_test.go
@@ -1,0 +1,356 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const wantStatusCommand = wantCommand + " statusline"
+
+// installStatus runs installStatusLineHooks the way `fence init` does, with
+// the fixed test commands and HOME isolated so the developer's real
+// ~/.claude/settings.json can't leak into the occupancy check.
+func installStatus(t *testing.T, path string, quiet, global bool) (hookInstallResult, string, error) {
+	t.Helper()
+	return installStatusLineHooks(path, hookAgents[0], testSpecs(quiet), wantStatusCommand, global)
+}
+
+func statusLineCommandOf(t *testing.T, path string) string {
+	t.Helper()
+	cmd, _ := asMap(readSettings(t, path)["statusLine"])["command"].(string)
+	return cmd
+}
+
+func TestInstallStatusLineHooks(t *testing.T) {
+	legacyInstall := `{"hooks":{
+		"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"` + wantCommand + `"}]}],
+		"SessionStart":[{"matcher":"startup|resume|clear","hooks":[{"type":"command","command":"` + wantSessionCommand + `"}]}]}}`
+
+	tests := []struct {
+		name        string
+		initial     string // "" means the settings file does not exist yet
+		quiet       bool
+		want        hookInstallResult
+		wantNote    bool
+		preCmds     []string // expected PreToolUse commands after the call
+		sessionCmds []string // expected SessionStart commands (nil = none)
+		slCommand   string   // expected statusLine.command ("" = key absent)
+	}{
+		{
+			name:      "creates settings with the hook and the status line",
+			want:      hookInstalled,
+			preCmds:   []string{wantCommand},
+			slCommand: wantStatusCommand,
+		},
+		{
+			// The upgrade path from banner-era installs: the SessionStart hook
+			// is replaced by the status line, PreToolUse stays.
+			name:      "migrates a banner-era install to the status line",
+			initial:   legacyInstall,
+			want:      hookInstalled,
+			preCmds:   []string{wantCommand},
+			slCommand: wantStatusCommand,
+		},
+		{
+			name: "idempotent when already converged",
+			initial: `{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"` + wantCommand + `"}]}]},
+				"statusLine":{"type":"command","command":"` + wantStatusCommand + `"}}`,
+			want:      hookUnchanged,
+			preCmds:   []string{wantCommand},
+			slCommand: wantStatusCommand,
+		},
+		{
+			// The brew-cask trap again, now for the statusLine entry.
+			name: "heals a stale binary path in the status line",
+			initial: `{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"` + wantCommand + `"}]}]},
+				"statusLine":{"type":"command","command":"/opt/homebrew/Caskroom/fence/0.0.2/fence hook claude-code statusline"}}`,
+			want:      hookUpdated,
+			preCmds:   []string{wantCommand},
+			slCommand: wantStatusCommand,
+		},
+		{
+			name: "preserves an unmanaged flag while healing the status line",
+			initial: `{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"` + wantCommand + `"}]}]},
+				"statusLine":{"type":"command","command":"/stale/fence hook claude-code statusline --rules /custom.yaml"}}`,
+			want:      hookUpdated,
+			preCmds:   []string{wantCommand},
+			slCommand: wantStatusCommand + " --rules /custom.yaml",
+		},
+		{
+			// The user's own status line owns the slot: Fence must not take it
+			// (or shadow it) and announces through the banner instead.
+			name:        "a foreign status line falls back to the banner",
+			initial:     `{"statusLine":{"type":"command","command":"~/.claude/statusline.sh"}}`,
+			want:        hookInstalled,
+			wantNote:    true,
+			preCmds:     []string{wantCommand},
+			sessionCmds: []string{wantSessionCommand},
+			slCommand:   "~/.claude/statusline.sh",
+		},
+		{
+			// Even a statusLine shape we don't understand belongs to the user.
+			name:        "an unrecognized statusLine shape counts as foreign",
+			initial:     `{"statusLine":{"type":"static","text":"hello"}}`,
+			want:        hookInstalled,
+			wantNote:    true,
+			preCmds:     []string{wantCommand},
+			sessionCmds: []string{wantSessionCommand},
+		},
+		{
+			name: "quiet toggles the PreToolUse hook, not the status line",
+			initial: `{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"` + wantCommand + `"}]}]},
+				"statusLine":{"type":"command","command":"` + wantStatusCommand + `"}}`,
+			quiet:     true,
+			want:      hookUpdated,
+			preCmds:   []string{wantCommand + " --quiet"},
+			slCommand: wantStatusCommand,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			path := filepath.Join(t.TempDir(), ".claude", "settings.json")
+			if tt.initial != "" {
+				writeTestFile(t, path, tt.initial)
+			}
+
+			got, note, err := installStatus(t, path, tt.quiet, false)
+			if err != nil {
+				t.Fatalf("installStatusLineHooks: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("result = %v, want %v", got, tt.want)
+			}
+			if (note != "") != tt.wantNote {
+				t.Fatalf("note = %q, wantNote %v", note, tt.wantNote)
+			}
+
+			for event, want := range map[string][]string{
+				"PreToolUse":   tt.preCmds,
+				"SessionStart": tt.sessionCmds,
+			} {
+				if cmds := hookCommands(t, path, event); !reflect.DeepEqual(cmds, want) {
+					t.Errorf("%s commands = %q, want %q", event, cmds, want)
+				}
+			}
+			if cmd := statusLineCommandOf(t, path); cmd != tt.slCommand {
+				t.Errorf("statusLine.command = %q, want %q", cmd, tt.slCommand)
+			}
+		})
+	}
+}
+
+// Keys the user added to Fence's own statusLine entry (padding, say) must
+// survive a converge: init owns the command, nothing else.
+func TestInstallStatusLineHooksKeepsUserKeys(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	path := filepath.Join(t.TempDir(), "settings.json")
+	writeTestFile(t, path, `{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"`+wantCommand+`"}]}]},
+		"statusLine":{"type":"command","command":"/stale/fence hook claude-code statusline","padding":2}}`)
+
+	if got, _, err := installStatus(t, path, false, false); err != nil || got != hookUpdated {
+		t.Fatalf("installStatusLineHooks = %v, %v; want hookUpdated, nil", got, err)
+	}
+
+	sl := asMap(readSettings(t, path)["statusLine"])
+	if cmd := sl["command"]; cmd != wantStatusCommand {
+		t.Errorf("statusLine.command = %v, want %q", cmd, wantStatusCommand)
+	}
+	if pad := sl["padding"]; pad != float64(2) {
+		t.Errorf("statusLine.padding = %v, want 2 kept", pad)
+	}
+}
+
+// A project install must not shadow a status line configured in the
+// user-level settings: shadowing clobbers the user's setup in effect.
+func TestInstallStatusLineHooksRespectsUserScope(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeTestFile(t, filepath.Join(home, ".claude", "settings.json"),
+		`{"statusLine":{"type":"command","command":"ccusage statusline"}}`)
+	path := filepath.Join(t.TempDir(), ".claude", "settings.json")
+
+	got, note, err := installStatus(t, path, false, false)
+	if err != nil || got != hookInstalled {
+		t.Fatalf("installStatusLineHooks = %v, %v; want hookInstalled, nil", got, err)
+	}
+	if note == "" {
+		t.Error("want a note explaining the fallback to the banner")
+	}
+	if cmd := statusLineCommandOf(t, path); cmd != "" {
+		t.Errorf("project statusLine = %q, want none (it would shadow the user's)", cmd)
+	}
+	if cmds := hookCommands(t, path, "SessionStart"); !reflect.DeepEqual(cmds, []string{wantSessionCommand}) {
+		t.Errorf("SessionStart commands = %q, want the banner fallback", cmds)
+	}
+}
+
+// Fence's own status line in the user scope is not a conflict: a project
+// install shadowing it changes nothing the user configured.
+func TestInstallStatusLineHooksIgnoresOwnUserScopeEntry(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeTestFile(t, filepath.Join(home, ".claude", "settings.json"),
+		`{"statusLine":{"type":"command","command":"`+wantStatusCommand+`"}}`)
+	path := filepath.Join(t.TempDir(), ".claude", "settings.json")
+
+	got, note, err := installStatus(t, path, false, false)
+	if err != nil || got != hookInstalled || note != "" {
+		t.Fatalf("installStatusLineHooks = %v, %q, %v; want hookInstalled, no note, nil", got, note, err)
+	}
+	if cmd := statusLineCommandOf(t, path); cmd != wantStatusCommand {
+		t.Errorf("statusLine.command = %q, want %q", cmd, wantStatusCommand)
+	}
+}
+
+// settings.local.json overrides the project settings, so a status line there
+// would shadow whatever Fence installs — respect it the same way.
+func TestInstallStatusLineHooksRespectsLocalScope(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	dir := filepath.Join(t.TempDir(), ".claude")
+	writeTestFile(t, filepath.Join(dir, "settings.local.json"),
+		`{"statusLine":{"type":"command","command":"my-statusline.sh"}}`)
+	path := filepath.Join(dir, "settings.json")
+
+	got, note, err := installStatus(t, path, false, false)
+	if err != nil || got != hookInstalled {
+		t.Fatalf("installStatusLineHooks = %v, %v; want hookInstalled, nil", got, err)
+	}
+	if note == "" {
+		t.Error("want a note explaining the fallback to the banner")
+	}
+	if cmd := statusLineCommandOf(t, path); cmd != "" {
+		t.Errorf("statusLine = %q, want none (settings.local.json owns the slot)", cmd)
+	}
+}
+
+// A --global install converges the user file itself; other scopes are not
+// consulted (a project's settings can't be known from here).
+func TestInstallStatusLineHooksGlobal(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path := filepath.Join(home, ".claude", "settings.json")
+
+	got, note, err := installStatus(t, path, false, true)
+	if err != nil || got != hookInstalled || note != "" {
+		t.Fatalf("installStatusLineHooks = %v, %q, %v; want hookInstalled, no note, nil", got, note, err)
+	}
+	if cmd := statusLineCommandOf(t, path); cmd != wantStatusCommand {
+		t.Errorf("statusLine.command = %q, want %q", cmd, wantStatusCommand)
+	}
+}
+
+func TestInstallStatusLineHooksUnchangedDoesNotRewrite(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	path := filepath.Join(t.TempDir(), "settings.json")
+	// Deliberately not in MarshalIndent formatting: a rewrite would reformat.
+	initial := `{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"` + wantCommand + `"}]}]},` +
+		`"statusLine":{"type":"command","command":"` + wantStatusCommand + `"}}`
+	writeTestFile(t, path, initial)
+
+	if got, _, err := installStatus(t, path, false, false); err != nil || got != hookUnchanged {
+		t.Fatalf("installStatusLineHooks = %v, %v; want hookUnchanged, nil", got, err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != initial {
+		t.Errorf("file was rewritten despite no change:\n%s", data)
+	}
+}
+
+func TestInstallStatusLineHooksRejectsInvalidJSON(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	path := filepath.Join(t.TempDir(), "settings.json")
+	writeTestFile(t, path, "{not json")
+	if _, _, err := installStatus(t, path, false, false); err == nil {
+		t.Fatal("expected an error for invalid JSON, got nil")
+	}
+}
+
+// init followed by uninstall must hand the file back as it was, statusLine
+// included.
+func TestRemoveHooksStatusLineRoundTrip(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	path := filepath.Join(t.TempDir(), "settings.json")
+	writeTestFile(t, path, `{"model":"opus"}`)
+
+	if _, _, err := installStatus(t, path, false, false); err != nil {
+		t.Fatalf("installStatusLineHooks: %v", err)
+	}
+	if got, err := removeHooks(path, claudeInvocation); err != nil || got != hookRemoved {
+		t.Fatalf("removeHooks = %v, %v; want hookRemoved, nil", got, err)
+	}
+
+	settings := readSettings(t, path)
+	if _, ok := settings["hooks"]; ok {
+		t.Errorf("hooks key left behind: %v", settings["hooks"])
+	}
+	if _, ok := settings["statusLine"]; ok {
+		t.Errorf("statusLine key left behind: %v", settings["statusLine"])
+	}
+	if settings["model"] != "opus" {
+		t.Errorf("model = %v, want opus", settings["model"])
+	}
+}
+
+func TestRemoveHooksRemovesFenceStatusLine(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	writeTestFile(t, path, `{"model":"opus","statusLine":{"type":"command","command":"`+wantStatusCommand+`"}}`)
+
+	if got, err := removeHooks(path, claudeInvocation); err != nil || got != hookRemoved {
+		t.Fatalf("removeHooks = %v, %v; want hookRemoved, nil", got, err)
+	}
+	settings := readSettings(t, path)
+	if _, ok := settings["statusLine"]; ok {
+		t.Errorf("statusLine key left behind: %v", settings["statusLine"])
+	}
+	if settings["model"] != "opus" {
+		t.Errorf("model = %v, want opus", settings["model"])
+	}
+}
+
+// Uninstall must never take a status line that is not Fence's.
+func TestRemoveHooksKeepsForeignStatusLine(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	initial := `{"statusLine":{"type":"command","command":"~/.claude/statusline.sh"}}`
+	writeTestFile(t, path, initial)
+
+	if got, err := removeHooks(path, claudeInvocation); err != nil || got != hookAbsent {
+		t.Fatalf("removeHooks = %v, %v; want hookAbsent, nil", got, err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != initial {
+		t.Errorf("file was rewritten despite no change:\n%s", data)
+	}
+}
+
+// The real command end to end: a fresh `fence init` writes the status line,
+// not the banner hook, and says how to activate it.
+func TestInitCommandInstallsStatusLine(t *testing.T) {
+	isolateHome(t)
+	out := runFence(t, "", "init")
+	if !strings.Contains(out, "Installed the Fence hooks") {
+		t.Fatalf("init output = %q, want an install confirmation", out)
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(wd, ".claude", "settings.json")
+	if cmd := statusLineCommandOf(t, path); !strings.HasSuffix(cmd, " hook claude-code statusline") {
+		t.Errorf("statusLine.command = %q, want a statusline invocation", cmd)
+	}
+	if cmds := hookCommands(t, path, "SessionStart"); cmds != nil {
+		t.Errorf("SessionStart commands = %q, want none (the status line replaced the banner)", cmds)
+	}
+}

--- a/internal/cli/statusline_test.go
+++ b/internal/cli/statusline_test.go
@@ -189,6 +189,33 @@ func TestInstallStatusLineHooksRespectsUserScope(t *testing.T) {
 	}
 }
 
+// A Fence status line installed before the user configured their own must
+// stop shadowing it: the next converge removes Fence's entry from the target
+// and falls back to the banner.
+func TestInstallStatusLineHooksStopsShadowingOnRerun(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeTestFile(t, filepath.Join(home, ".claude", "settings.json"),
+		`{"statusLine":{"type":"command","command":"ccusage statusline"}}`)
+	path := filepath.Join(t.TempDir(), ".claude", "settings.json")
+	writeTestFile(t, path, `{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"`+wantCommand+`"}]}]},
+		"statusLine":{"type":"command","command":"`+wantStatusCommand+`"}}`)
+
+	got, note, err := installStatus(t, path, false, false)
+	if err != nil || got != hookInstalled {
+		t.Fatalf("installStatusLineHooks = %v, %v; want hookInstalled, nil", got, err)
+	}
+	if note == "" {
+		t.Error("want a note explaining the fallback to the banner")
+	}
+	if cmd := statusLineCommandOf(t, path); cmd != "" {
+		t.Errorf("statusLine = %q, want removed (it shadowed the user's)", cmd)
+	}
+	if cmds := hookCommands(t, path, "SessionStart"); !reflect.DeepEqual(cmds, []string{wantSessionCommand}) {
+		t.Errorf("SessionStart commands = %q, want the banner fallback", cmds)
+	}
+}
+
 // Fence's own status line in the user scope is not a conflict: a project
 // install shadowing it changes nothing the user configured.
 func TestInstallStatusLineHooksIgnoresOwnUserScopeEntry(t *testing.T) {

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 
@@ -14,11 +13,12 @@ func newUninstallCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "uninstall [agent]",
 		Short: "Remove the Fence hooks from an agent's settings",
-		Long: "The exit door: removes the hooks `fence init` installed from an agent's\n" +
-			"settings, leaving everything else in the file untouched. The agent is\n" +
-			"claude-code (default), codex, or opencode (whose generated plugin file\n" +
-			"is deleted instead). By default it edits the project settings (./.claude,\n" +
-			"./.codex or ./.opencode); use --global for the user-level file under ~.\n\n" +
+		Long: "The exit door: removes everything `fence init` installed from an agent's\n" +
+			"settings — the hooks and Fence's status line — leaving everything else\n" +
+			"in the file untouched. The agent is claude-code (default), codex, or\n" +
+			"opencode (whose generated plugin file is deleted instead). By default it\n" +
+			"edits the project settings (./.claude, ./.codex or ./.opencode); use\n" +
+			"--global for the user-level file under ~.\n\n" +
 			"Rulepacks installed with `fence add` are not touched — remove those with\n" +
 			"`fence remove <pack>`.",
 		Args: cobra.MaximumNArgs(1),
@@ -68,80 +68,83 @@ const (
 	hookRemoved
 )
 
-// removeHooks deletes exactly the Fence hook commands for one agent from the
-// settings file at path — recognized the same way init converges them, via
-// containsHook, so a stale binary path, a hand-added flag, or a user-narrowed
-// matcher all still count as ours. Containers that held only Fence entries
-// are removed too (an entry whose hooks list empties, an event whose entries
-// empty, the hooks key itself), so init followed by uninstall leaves the
-// settings as they were. Everything else is preserved, and when there is
-// nothing to remove the file is not rewritten — or created.
+// removeHooks deletes exactly the Fence entries for one agent from the
+// settings file at path — the hook commands and a Fence-owned statusLine,
+// recognized the same way init converges them, via containsHook, so a stale
+// binary path, a hand-added flag, or a user-narrowed matcher all still count
+// as ours. Containers that held only Fence entries are removed too (an entry
+// whose hooks list empties, an event whose entries empty, the hooks key
+// itself), so init followed by uninstall leaves the settings as they were.
+// Everything else is preserved — a status line that is not Fence's above all
+// — and when there is nothing to remove the file is not rewritten, or created.
 func removeHooks(path, invocation string) (hookRemoveResult, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return hookAbsent, nil
-		}
-		return hookAbsent, err
-	}
-	if len(data) == 0 {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
 		return hookAbsent, nil
 	}
-	settings := map[string]any{}
-	if err := json.Unmarshal(data, &settings); err != nil {
-		return hookAbsent, fmt.Errorf("%s is not valid JSON: %w", path, err)
+	settings, err := loadSettings(path)
+	if err != nil {
+		return hookAbsent, err
 	}
 
 	hooks := asMap(settings["hooks"])
 	removed := false
 	for _, event := range []string{"PreToolUse", "SessionStart"} {
-		entries := asSlice(hooks[event])
-		if entries == nil {
-			continue
-		}
-		keptEntries := make([]any, 0, len(entries))
-		for _, e := range entries {
-			em := asMap(e)
-			inner := asSlice(em["hooks"])
-			keptInner := make([]any, 0, len(inner))
-			for _, h := range inner {
-				if cmd, ok := asMap(h)["command"].(string); ok && containsHook(cmd, invocation) {
-					removed = true
-					continue
-				}
-				keptInner = append(keptInner, h)
-			}
-			if len(keptInner) == 0 && len(inner) > 0 {
-				continue // the entry existed only to hold Fence hooks
-			}
-			if len(keptInner) < len(inner) {
-				em["hooks"] = keptInner
-			}
-			keptEntries = append(keptEntries, e)
-		}
-		if len(keptEntries) == 0 {
-			delete(hooks, event)
-		} else {
-			hooks[event] = keptEntries
-		}
+		removed = removeEventHooks(hooks, event, invocation) || removed
+	}
+	if removed && len(hooks) == 0 {
+		delete(settings, "hooks")
+	}
+
+	if cmd, ok := asMap(settings["statusLine"])["command"].(string); ok && containsHook(cmd, invocation) {
+		delete(settings, "statusLine")
+		removed = true
 	}
 
 	if !removed {
 		return hookAbsent, nil
 	}
-	if len(hooks) == 0 {
-		delete(settings, "hooks")
-	} else {
-		settings["hooks"] = hooks
-	}
-
-	out, err := json.MarshalIndent(settings, "", "  ")
-	if err != nil {
-		return hookAbsent, err
-	}
-	out = append(out, '\n')
-	if err := os.WriteFile(path, out, 0o644); err != nil {
+	if err := saveSettings(path, settings); err != nil {
 		return hookAbsent, err
 	}
 	return hookRemoved, nil
+}
+
+// removeEventHooks deletes the Fence hook commands under one event of a
+// settings hooks map, pruning containers that held only Fence entries, and
+// reports whether it removed anything.
+func removeEventHooks(hooks map[string]any, event, invocation string) bool {
+	entries := asSlice(hooks[event])
+	if entries == nil {
+		return false
+	}
+	removed := false
+	keptEntries := make([]any, 0, len(entries))
+	for _, e := range entries {
+		em := asMap(e)
+		inner := asSlice(em["hooks"])
+		keptInner := make([]any, 0, len(inner))
+		for _, h := range inner {
+			if cmd, ok := asMap(h)["command"].(string); ok && containsHook(cmd, invocation) {
+				removed = true
+				continue
+			}
+			keptInner = append(keptInner, h)
+		}
+		if len(keptInner) == 0 && len(inner) > 0 {
+			continue // the entry existed only to hold Fence hooks
+		}
+		if len(keptInner) < len(inner) {
+			em["hooks"] = keptInner
+		}
+		keptEntries = append(keptEntries, e)
+	}
+	if !removed {
+		return false
+	}
+	if len(keptEntries) == 0 {
+		delete(hooks, event)
+	} else {
+		hooks[event] = keptEntries
+	}
+	return true
 }

--- a/internal/cli/uninstall_test.go
+++ b/internal/cli/uninstall_test.go
@@ -170,7 +170,8 @@ func TestUninstallCommand(t *testing.T) {
 	path := filepath.Join(wd, ".claude", "settings.json")
 	writeTestFile(t, path, `{"model":"opus","hooks":{
 		"PreToolUse":[{"matcher":"Bash|Write","hooks":[{"type":"command","command":"`+wantCommand+`"}]}],
-		"SessionStart":[{"matcher":"startup|resume|clear","hooks":[{"type":"command","command":"`+wantSessionCommand+`"}]}]}}`)
+		"SessionStart":[{"matcher":"startup|resume|clear","hooks":[{"type":"command","command":"`+wantSessionCommand+`"}]}]},
+		"statusLine":{"type":"command","command":"`+wantCommand+` statusline"}}`)
 
 	out := runFence(t, "", "uninstall")
 	if !strings.Contains(out, "Removed the Fence hooks") {
@@ -180,6 +181,9 @@ func TestUninstallCommand(t *testing.T) {
 	settings := readSettings(t, path)
 	if _, ok := settings["hooks"]; ok {
 		t.Fatalf("hooks left in settings after uninstall: %v", settings["hooks"])
+	}
+	if _, ok := settings["statusLine"]; ok {
+		t.Fatalf("statusLine left in settings after uninstall: %v", settings["statusLine"])
 	}
 	if settings["model"] != "opus" {
 		t.Fatalf("model = %v, want opus preserved", settings["model"])

--- a/internal/cli/uninstall_test.go
+++ b/internal/cli/uninstall_test.go
@@ -131,6 +131,26 @@ func TestRemoveHooksRoundTrip(t *testing.T) {
 	}
 }
 
+// A hooks key holding something Fence doesn't understand must survive a
+// statusLine removal. Pins the statement order in removeHooks: the hooks-key
+// prune runs before the statusLine removal flips `removed`, so an unrelated
+// value there is never mistaken for an emptied container.
+func TestRemoveHooksKeepsNonMapHooksKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	writeTestFile(t, path, `{"hooks":"keep","statusLine":{"type":"command","command":"`+wantCommand+` statusline"}}`)
+
+	if got, err := removeHooks(path, claudeInvocation); err != nil || got != hookRemoved {
+		t.Fatalf("removeHooks = %v, %v; want hookRemoved, nil", got, err)
+	}
+	settings := readSettings(t, path)
+	if settings["hooks"] != "keep" {
+		t.Errorf("hooks = %v, want the unrelated value kept", settings["hooks"])
+	}
+	if _, ok := settings["statusLine"]; ok {
+		t.Errorf("statusLine key left behind: %v", settings["statusLine"])
+	}
+}
+
 // A no-op uninstall must not rewrite (and reformat) the file.
 func TestRemoveHooksNoOpDoesNotRewrite(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "settings.json")


### PR DESCRIPTION
## What

The SessionStart chat banner becomes a **persistent status line**: `fence init` now writes a `statusLine` entry running the new `fence hook claude-code statusline` entrypoint, which prints one plain-text line Claude Code renders at the bottom of the UI for the whole session:

```
🚧 Fence v1.2.0 · 1 pack · 19 rules
🚧 Fence v1.2.0 · 1 pack · 19 rules — ⚠️ 1 rulepack failed to load
🚧 Fence — ⚠️ rules failed to load, tool calls NOT screened
```

Proof of protection stays on screen instead of scrolling away — the threat model's "check for the barrier" now has a barrier that's always visible.

## Behavior

| Situation | `fence init` does |
|---|---|
| Slot free | Installs `statusLine` + `PreToolUse`; no SessionStart hook |
| Banner-era install | Migrates: removes Fence's SessionStart hook, adds the statusLine |
| Fence's own statusLine (stale path, flags) | Converges in place; user keys like `padding` survive |
| **Someone else's status line** — in the target, or a scope a project install would shadow (`~/.claude/settings.json`) or be shadowed by (`settings.local.json`) | Left untouched; falls back to the SessionStart banner and prints a note with the one-liner for combining the two |

`fence uninstall` removes a Fence-owned `statusLine`, never a foreign one. The `session-start` entrypoint keeps working forever — settings written by older installs still invoke it. Codex and OpenCode keep their banners (no status-line surface exists there).

## How

- `internal/cli/statusline.go` (new): occupancy check + converge for the single-slot `statusLine` key.
- Settings handling in init/uninstall splits into load → converge → save, so hook entries and the statusLine key converge on one in-memory map with a single file write; per-event removal is shared between uninstall and the migration.
- `claudecode.WriteStatusLine`/`WriteStatusLineDegraded` mirror the banner writers, but emit plain text — the statusLine protocol renders stdout directly, no JSON envelope.

## Testing

- Table-driven tests for the line formatting, the converge/occupancy/migration matrix (fresh, legacy, stale-path, unmanaged flags, foreign slot in each scope, quiet toggle, no-rewrite idempotency), and uninstall (removes ours, keeps foreign, full round trip).
- Driven end to end with the real binary: fresh init, re-run, banner-era migration, foreign-statusline fallback, uninstall round trip, degraded line.
- Verified in a live Claude Code session — the status line renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UFs7rGbzRH8ndcybi5Gj1k