### PR TITLE
init: stand down when a Claude Code plugin already runs the Fence hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,8 +48,9 @@ central audit, and approval workflows out of scope.
 - `internal/registry/` — fetch + sha256-verify packs from a static index
   (`registry/` in this repo, read raw off main). Only the explicit commands
   import it — **nothing on the eval path may ever touch the network**.
-- `internal/cli/` — Cobra commands: `check`, `hook`, `init`, `add`, `search`,
-  `update`, `remove`, `version`.
+- `internal/cli/` — Cobra commands: `check`, `hook`, `init`, `uninstall`, `add`,
+  `search`, `update`, `remove`, `version`. `plugins.go` detects a Claude Code
+  plugin that already runs the Fence hook (see Conventions).
 - `cmd/fence/` — entrypoint; `version` is injected via `-ldflags "-X main.version=..."`.
 
 ## Conventions (load-bearing)
@@ -65,6 +66,14 @@ central audit, and approval workflows out of scope.
   exit codes.
 - **Every detector needs a table-driven test** asserting both the catch AND the
   safe cases (the false-positive guard). See `internal/**/*_test.go`.
+- **One hook per agent, and detection fails toward installing.** A Claude Code
+  plugin can register a Fence hook of its own (the hoop plugin does), so `init`
+  checks for one and then contributes only the status line — the piece no
+  plugin can supply, since `statusLine` is settings-only — removing a duplicate
+  an earlier init left. Detection is conservative on purpose: a false negative
+  only duplicates work, a false positive skips the hook and silently leaves the
+  user unguarded, so every uncertainty resolves to "install it". `--force-hooks`
+  and `--statusline-only`/`--hooks-only` let the user override the split.
 - Extension points: new agent = new adapter; new detection = new analyzer fact +
   `Match` predicate. The engine and rulepacks stay agent-agnostic.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,8 @@ central audit, and approval workflows out of scope.
   only duplicates work, a false positive skips the hook and silently leaves the
   user unguarded, so every uncertainty resolves to "install it". `--force-hooks`
   and `--statusline-only`/`--hooks-only` let the user override the split.
+  The plugin side lives in hoophq/claude-marketplace, whose `doctor.sh` and docs
+  name fence CLI flags verbatim — changing init/uninstall UX means syncing that repo.
 - Extension points: new agent = new adapter; new detection = new analyzer fact +
   `Match` predicate. The engine and rulepacks stay agent-agnostic.
 
@@ -93,6 +95,11 @@ central audit, and approval workflows out of scope.
 
 ## Gotchas
 
+- CLI tests: use `runFence`/`runFenceErr` + `isolateHome(t)` (helpers in
+  `hook_test.go`/`opencode_test.go`) — init, statusline, and plugin detection
+  read `~/.claude`, so an unisolated test reads the developer's real settings.
+  E2e tests can't exercise `init`'s own output under `go test` (the binary is
+  `cli.test`, so `containsHook`'s needle misses) — seed settings JSON directly.
 - gopls may report false `BrokenImport` / "not in a workspace module" errors if
   this repo is opened inside another module's `go.work`. Ignore IDE diagnostics
   here — trust `go build ./...` and `go test ./...`.

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -127,6 +127,16 @@ func newInitCommand() *cobra.Command {
 			if err != nil {
 				return fail(cmd, err)
 			}
+			// These flags split hook from status-line ownership, which only
+			// exists for Claude Code. Accepting them elsewhere would install
+			// hooks while reporting a status line — a lie in both directions.
+			if !agent.statusLine {
+				for flag, set := range map[string]bool{"--statusline-only": statusLineOnly, "--force-hooks": forceHooks} {
+					if set {
+						return fail(cmd, fmt.Errorf("%s only applies to claude-code: %s has no status line, its hooks are always installed whole", flag, agent.display))
+					}
+				}
+			}
 			var path, note string
 			var result hookInstallResult
 			skipHooks := statusLineOnly

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -115,7 +115,9 @@ func newInitCommand() *cobra.Command {
 			"When a Claude Code plugin already provides the Fence hook, init installs\n" +
 			"only the status line (which no plugin can provide) rather than a second\n" +
 			"hook that would evaluate every tool call twice — and removes a duplicate\n" +
-			"an earlier init left behind. Use --force-hooks to install ours anyway.",
+			"an earlier init left behind. Use --force-hooks to install ours anyway.\n" +
+			"A --global install always writes the hooks: it guards every project, and\n" +
+			"any single project can disable the plugin.",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := initSupportedOS(runtime.GOOS); err != nil {
@@ -194,19 +196,31 @@ func newInitCommand() *cobra.Command {
 
 // hookAlreadyProvided reports whether an enabled agent plugin already runs the
 // Fence hook, so init should contribute only the status line. The settings
-// scopes that decide which plugins are enabled are the user-level file and the
-// file being written, most specific last.
+// scopes that decide which plugins are enabled are the user-level file, the
+// file being written, and the project's settings.local.json, most specific
+// last — any scope that explicitly disables the plugin means no provider.
+//
+// A global install never stands down: the user-level hook guards every
+// project, but plugin enablement is per-scope, so any single project can
+// disable the plugin and would then be left with no hook at all — a gap this
+// function cannot rule out from here. Duplicated evaluation in plugin-enabled
+// projects is noise; an unguarded project is the one outcome that must not
+// happen. Global users who accept the trade-off have --statusline-only.
 func hookAlreadyProvided(agent hookAgent, path string, global bool) (bool, string) {
-	scopes := make([]map[string]any, 0, 2)
-	if !global {
-		if home, err := os.UserHomeDir(); err == nil {
-			if user, err := loadSettings(filepath.Join(home, ".claude", "settings.json")); err == nil {
-				scopes = append(scopes, user)
-			}
+	if global {
+		return false, ""
+	}
+	scopes := make([]map[string]any, 0, 3)
+	if home, err := os.UserHomeDir(); err == nil {
+		if user, err := loadSettings(filepath.Join(home, ".claude", "settings.json")); err == nil {
+			scopes = append(scopes, user)
 		}
 	}
 	if target, err := loadSettings(path); err == nil {
 		scopes = append(scopes, target)
+	}
+	if local, err := loadSettings(filepath.Join(filepath.Dir(path), "settings.local.json")); err == nil {
+		scopes = append(scopes, local)
 	}
 	provider, found := findPluginHookProvider(agent, scopes...)
 	if !found {

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -40,6 +40,7 @@ type hookAgent struct {
 	trustNote      string // printed after install (Codex's hook-trust step)
 	plugin         bool   // installs a generated plugin file instead of JSON hook entries
 	statusLine     bool   // announces via a statusLine entry, banner hook as fallback
+	pluginHooks    bool   // the agent has a plugin system that can supply hooks of its own
 }
 
 var hookAgents = []hookAgent{
@@ -52,6 +53,7 @@ var hookAgents = []hookAgent{
 		preMatcher:     toolMatcher,
 		sessionMatcher: sessionStartMatcher,
 		statusLine:     true,
+		pluginHooks:    true,
 	},
 	{
 		name:           "codex",
@@ -88,8 +90,10 @@ func resolveAgent(args []string) (hookAgent, error) {
 
 func newInitCommand() *cobra.Command {
 	var (
-		global bool
-		quiet  bool
+		global         bool
+		quiet          bool
+		statusLineOnly bool
+		forceHooks     bool
 	)
 
 	cmd := &cobra.Command{
@@ -107,7 +111,11 @@ func newInitCommand() *cobra.Command {
 			"The change is idempotent and preserves any existing settings. Re-running\n" +
 			"init always converges the hook commands, so it also heals a stale binary\n" +
 			"path, migrates a banner-era install to the status line, and toggles\n" +
-			"--quiet on or off.",
+			"--quiet on or off.\n\n" +
+			"When a Claude Code plugin already provides the Fence hook, init installs\n" +
+			"only the status line (which no plugin can provide) rather than a second\n" +
+			"hook that would evaluate every tool call twice — and removes a duplicate\n" +
+			"an earlier init left behind. Use --force-hooks to install ours anyway.",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := initSupportedOS(runtime.GOOS); err != nil {
@@ -119,6 +127,7 @@ func newInitCommand() *cobra.Command {
 			}
 			var path, note string
 			var result hookInstallResult
+			skipHooks := statusLineOnly
 			switch {
 			case agent.plugin:
 				if path, err = opencodePluginPath(global); err == nil {
@@ -126,8 +135,13 @@ func newInitCommand() *cobra.Command {
 				}
 			case agent.statusLine:
 				if path, err = settingsPath(agent, global); err == nil {
+					var providerNote string
+					if !skipHooks && !forceHooks {
+						skipHooks, providerNote = hookAlreadyProvided(agent, path, global)
+					}
 					result, note, err = installStatusLineHooks(path, agent,
-						desiredHooks(agent, quiet), hookInvocation(agent)+" statusline", global)
+						desiredHooks(agent, quiet), hookInvocation(agent)+" statusline", global, skipHooks)
+					note = joinNotes(providerNote, note)
 				}
 			default:
 				if path, err = settingsPath(agent, global); err == nil {
@@ -138,8 +152,11 @@ func newInitCommand() *cobra.Command {
 				return fail(cmd, err)
 			}
 			what, updated := "hooks", "hook commands"
-			if agent.plugin {
+			switch {
+			case agent.plugin:
 				what, updated = "plugin", "plugin"
+			case skipHooks:
+				what, updated = "status line", "status line"
 			}
 			switch result {
 			case hookInstalled:
@@ -164,11 +181,51 @@ func newInitCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&global, "global", false, "install into the user-level settings under ~ instead of the project")
 	cmd.Flags().BoolVar(&quiet, "quiet", false,
 		"don't show a chat notice for allowed tool calls (re-run init without it to switch back)")
+	cmd.Flags().BoolVar(&statusLineOnly, "statusline-only", false,
+		"install only Fence's status line, never the hooks (for when something else runs the hook)")
+	cmd.Flags().BoolVar(&forceHooks, "force-hooks", false,
+		"install Fence's own hooks even when a plugin already provides them")
 	// --verbose asked for what is now the default; running it plain is correct.
 	cmd.Flags().Bool("verbose", true, "")
 	_ = cmd.Flags().MarkDeprecated("verbose",
 		"allowed-call notices are now the default; use --quiet to turn them off")
 	return cmd
+}
+
+// hookAlreadyProvided reports whether an enabled agent plugin already runs the
+// Fence hook, so init should contribute only the status line. The settings
+// scopes that decide which plugins are enabled are the user-level file and the
+// file being written, most specific last.
+func hookAlreadyProvided(agent hookAgent, path string, global bool) (bool, string) {
+	scopes := make([]map[string]any, 0, 2)
+	if !global {
+		if home, err := os.UserHomeDir(); err == nil {
+			if user, err := loadSettings(filepath.Join(home, ".claude", "settings.json")); err == nil {
+				scopes = append(scopes, user)
+			}
+		}
+	}
+	if target, err := loadSettings(path); err == nil {
+		scopes = append(scopes, target)
+	}
+	provider, found := findPluginHookProvider(agent, scopes...)
+	if !found {
+		return false, ""
+	}
+	return true, fmt.Sprintf("The %s plugin already provides the Fence hook, so only the status line was\n"+
+		"installed here — a second hook would evaluate every tool call twice.\n"+
+		"Use --force-hooks to install Fence's own hook anyway.", provider.name)
+}
+
+// joinNotes combines the notes init collected, skipping the empty ones.
+func joinNotes(notes ...string) string {
+	var kept []string
+	for _, n := range notes {
+		if n != "" {
+			kept = append(kept, n)
+		}
+	}
+	return strings.Join(kept, "\n")
 }
 
 // initSupportedOS refuses to install hooks where the hook path has never been

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -233,6 +233,24 @@ func TestInitLegacyVerboseFlagStillAccepted(t *testing.T) {
 	}
 }
 
+// The hook/status-line ownership split only exists for Claude Code. On other
+// agents the flags must be rejected outright — silently accepting them would
+// install hooks while the output claims a status line was written.
+func TestInitStatusLineFlagsRejectedWithoutStatusLine(t *testing.T) {
+	isolateHome(t)
+	for _, tc := range []struct{ agent, flag string }{
+		{"codex", "--statusline-only"},
+		{"codex", "--force-hooks"},
+		{"opencode", "--statusline-only"},
+		{"opencode", "--force-hooks"},
+	} {
+		err := runFenceErr(t, "init", tc.agent, tc.flag)
+		if err == nil || !strings.Contains(err.Error(), tc.flag) {
+			t.Errorf("init %s %s: err = %v, want an error naming the flag", tc.agent, tc.flag, err)
+		}
+	}
+}
+
 // A matcher the user narrowed (e.g. dropped WebFetch) must survive healing:
 // init converges commands, never matchers.
 func TestInstallHooksPreservesCustomMatcher(t *testing.T) {

--- a/internal/cli/plugins.go
+++ b/internal/cli/plugins.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -161,13 +162,22 @@ func pluginScriptPath(command, pluginRoot string) (string, bool) {
 	return path, true
 }
 
+// fenceWord matches Fence named as a whole word — a binary path segment
+// (/opt/homebrew/bin/fence), a resolver variable ("$FENCE"), the bare command
+// — but not an unrelated identifier that merely contains the letters
+// ("defence", "fenced").
+var fenceWord = regexp.MustCompile(`(?i)\bfence\b`)
+
 // scriptRunsFence reports whether a plugin's wrapper script invokes Fence's
 // hook for this agent. The binary reaches the script through a variable
 // ("$FENCE" hook claude-code), so containsHook cannot be reused — it keys on
-// the whole invocation including the binary. We require both halves of the
-// evidence: the agent-specific "hook <agent>" subcommand, and Fence named
-// somewhere in the script. Wrapper scripts are small; a size cap keeps a
-// pathological file from being read into memory.
+// the whole invocation including the binary. The evidence must look like an
+// actual invocation, not a mention: a single non-comment line naming Fence as
+// a word and carrying the agent-specific "hook <agent>" subcommand. Comments
+// are skipped and the two halves must share a line, because a script that
+// merely talks about Fence while running something else would otherwise make
+// init skip the hook and leave the user unguarded. Wrapper scripts are small;
+// a size cap keeps a pathological file from being read into memory.
 func scriptRunsFence(path string, agent hookAgent) bool {
 	info, err := os.Stat(path)
 	if err != nil || info.Size() > 64*1024 {
@@ -177,6 +187,15 @@ func scriptRunsFence(path string, agent hookAgent) bool {
 	if err != nil {
 		return false
 	}
-	body := string(data)
-	return strings.Contains(body, "hook "+agent.name) && strings.Contains(strings.ToLower(body), "fence")
+	needle := "hook " + agent.name
+	for line := range strings.Lines(string(data)) {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if strings.Contains(trimmed, needle) && fenceWord.MatchString(trimmed) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/cli/plugins.go
+++ b/internal/cli/plugins.go
@@ -1,0 +1,182 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Claude Code plugins can contribute PreToolUse hooks of their own, so a
+// machine can already be guarded before `fence init` ever runs — the hoop
+// plugin ships exactly such a hook. Installing ours on top makes Fence
+// evaluate every tool call twice: same verdict, doubled latency and doubled
+// chat notices. These helpers let init see that hook and stand down.
+//
+// Only Claude Code has this problem. Codex hooks live in the user's own
+// .codex/hooks.json with no plugin layer, and OpenCode's shim plugin is a file
+// Fence generates and owns outright.
+
+// pluginHookProvider is a plugin that already registers a Fence hook: who it
+// is, and the hooks file that proves it.
+type pluginHookProvider struct {
+	name   string // "hoop@hooplabs", as the user sees it in enabledPlugins
+	source string // the hooks.json that declares the hook
+}
+
+// installedPlugins is the shape of ~/.claude/plugins/installed_plugins.json
+// that we depend on. Everything else in that file is ignored, so Claude Code
+// can grow the format without breaking detection.
+type installedPlugins struct {
+	Plugins map[string][]struct {
+		InstallPath string `json:"installPath"`
+	} `json:"plugins"`
+}
+
+// findPluginHookProvider reports the enabled Claude Code plugin that already
+// provides a Fence PreToolUse hook, if any.
+//
+// Detection is deliberately conservative, because the two ways to be wrong are
+// not equally bad. A false negative installs a hook that duplicates the
+// plugin's: noisy, but the user stays guarded. A false positive makes init
+// skip the hook when nothing else provides it, leaving the user unguarded
+// while init reports success — the one outcome Fence must never produce. So a
+// provider is only reported on positive evidence that the plugin invokes this
+// agent's Fence hook, and every uncertainty (unreadable file, unparseable
+// JSON, plugin not explicitly enabled) resolves to "no provider".
+//
+// enabled carries the settings scopes that decide whether a plugin is on, most
+// specific last.
+func findPluginHookProvider(agent hookAgent, enabled ...map[string]any) (pluginHookProvider, bool) {
+	if !agent.pluginHooks {
+		return pluginHookProvider{}, false
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return pluginHookProvider{}, false
+	}
+	root := filepath.Join(home, ".claude", "plugins")
+	data, err := os.ReadFile(filepath.Join(root, "installed_plugins.json"))
+	if err != nil {
+		return pluginHookProvider{}, false
+	}
+	var installed installedPlugins
+	if json.Unmarshal(data, &installed) != nil {
+		return pluginHookProvider{}, false
+	}
+
+	for name, installs := range installed.Plugins {
+		if !pluginEnabled(name, enabled...) {
+			continue
+		}
+		for _, install := range installs {
+			if install.InstallPath == "" {
+				continue
+			}
+			hooksFile := filepath.Join(install.InstallPath, "hooks", "hooks.json")
+			if pluginDeclaresHook(hooksFile, install.InstallPath, agent) {
+				return pluginHookProvider{name: name, source: hooksFile}, true
+			}
+		}
+	}
+	return pluginHookProvider{}, false
+}
+
+// pluginEnabled reports whether a plugin is switched on. Absence is not
+// enablement: a plugin present in installed_plugins.json but never listed in
+// enabledPlugins contributes no hooks, so treating it as a provider would
+// disarm the user. Later scopes win, so a project can turn off what the user
+// level turned on.
+func pluginEnabled(name string, scopes ...map[string]any) bool {
+	on := false
+	for _, scope := range scopes {
+		if v, ok := asMap(scope["enabledPlugins"])[name].(bool); ok {
+			on = v
+		}
+	}
+	return on
+}
+
+// pluginDeclaresHook reports whether the plugin's hooks file registers a
+// PreToolUse hook that runs Fence for this agent.
+//
+// Two shapes count. A plugin may invoke Fence directly, which containsHook
+// recognizes exactly as it does in settings. More often it goes through a
+// wrapper script under ${CLAUDE_PLUGIN_ROOT} — the hoop plugin's fence-hook.sh
+// resolves the binary from PATH and fails open when it is missing — and then
+// the command names a script, not Fence. For that case we expand the plugin
+// root and read the script itself, so the evidence is still Fence being
+// invoked rather than a filename that merely looks right.
+func pluginDeclaresHook(hooksFile, pluginRoot string, agent hookAgent) bool {
+	data, err := os.ReadFile(hooksFile)
+	if err != nil {
+		return false
+	}
+	var declared struct {
+		Hooks map[string][]struct {
+			Hooks []struct {
+				Command string `json:"command"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if json.Unmarshal(data, &declared) != nil {
+		return false
+	}
+	for _, entry := range declared.Hooks["PreToolUse"] {
+		for _, h := range entry.Hooks {
+			if containsHook(h.Command, agent.invocation) {
+				return true
+			}
+			if script, ok := pluginScriptPath(h.Command, pluginRoot); ok && scriptRunsFence(script, agent) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// pluginScriptPath resolves the script a plugin hook command runs, when that
+// command is a plain invocation of a file inside the plugin. Anything with
+// shell syntax in it is left alone: we would be guessing at what actually runs,
+// and guessing is what disarms people.
+func pluginScriptPath(command, pluginRoot string) (string, bool) {
+	fields := strings.Fields(command)
+	if len(fields) == 0 {
+		return "", false
+	}
+	path := fields[0]
+	if strings.ContainsAny(command, "|&;<>()`\"'\\") {
+		return "", false
+	}
+	path = strings.ReplaceAll(path, "${CLAUDE_PLUGIN_ROOT}", pluginRoot)
+	path = strings.ReplaceAll(path, "$CLAUDE_PLUGIN_ROOT", pluginRoot)
+	if !filepath.IsAbs(path) {
+		return "", false
+	}
+	// Only trust scripts the plugin ships. A hook pointing somewhere else is
+	// outside what this plugin can vouch for.
+	if rel, err := filepath.Rel(pluginRoot, path); err != nil || strings.HasPrefix(rel, "..") {
+		return "", false
+	}
+	return path, true
+}
+
+// scriptRunsFence reports whether a plugin's wrapper script invokes Fence's
+// hook for this agent. The binary reaches the script through a variable
+// ("$FENCE" hook claude-code), so containsHook cannot be reused — it keys on
+// the whole invocation including the binary. We require both halves of the
+// evidence: the agent-specific "hook <agent>" subcommand, and Fence named
+// somewhere in the script. Wrapper scripts are small; a size cap keeps a
+// pathological file from being read into memory.
+func scriptRunsFence(path string, agent hookAgent) bool {
+	info, err := os.Stat(path)
+	if err != nil || info.Size() > 64*1024 {
+		return false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	body := string(data)
+	return strings.Contains(body, "hook "+agent.name) && strings.Contains(strings.ToLower(body), "fence")
+}

--- a/internal/cli/plugins_test.go
+++ b/internal/cli/plugins_test.go
@@ -140,6 +140,34 @@ func TestFindPluginHookProvider(t *testing.T) {
 			want:    false,
 		},
 		{
+			// The pinned false-positive guard for scriptRunsFence: both
+			// substrings present, but only in comments — the script talks
+			// about Fence without ever running it.
+			name: "script mentioning fence and the hook only in comments",
+			fixture: pluginFixture{name: plugin, hooks: preToolUse(wrapperCmd),
+				script: "#!/bin/sh\n# unlike fence, this guard has its own hook claude-code integration\n# fence users should uninstall fence first\nexec \"$OTHER_GUARD\" run\n"},
+			scopes: []map[string]any{enabledScope(plugin, true)},
+			want:   false,
+		},
+		{
+			// "fence" as a fragment of another word is not Fence: the word
+			// boundary requirement keeps $DEFENCE from reading as evidence.
+			name: "fence only as a substring of another identifier",
+			fixture: pluginFixture{name: plugin, hooks: preToolUse(wrapperCmd),
+				script: "#!/bin/sh\nexec \"$DEFENCE\" hook claude-code\n"},
+			scopes: []map[string]any{enabledScope(plugin, true)},
+			want:   false,
+		},
+		{
+			// The two halves of the evidence on different lines is a mention,
+			// not an invocation.
+			name: "fence and the hook subcommand on separate lines",
+			fixture: pluginFixture{name: plugin, hooks: preToolUse(wrapperCmd),
+				script: "#!/bin/sh\nFENCE=ignored\nexec \"$OTHER\" hook claude-code\n"},
+			scopes: []map[string]any{enabledScope(plugin, true)},
+			want:   false,
+		},
+		{
 			name:    "hook command with shell syntax is not resolved",
 			fixture: pluginFixture{name: plugin, hooks: preToolUse("sh -c '${CLAUDE_PLUGIN_ROOT}/scripts/hook.sh | tee /tmp/x'"), script: wrapperScript},
 			scopes:  []map[string]any{enabledScope(plugin, true)},

--- a/internal/cli/plugins_test.go
+++ b/internal/cli/plugins_test.go
@@ -1,0 +1,362 @@
+package cli
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+)
+
+// The wrapper the hoop plugin actually ships, trimmed to the parts detection
+// keys on: Fence resolved into a variable, then invoked with the agent's hook
+// subcommand. The binary never appears literally, which is why containsHook
+// alone cannot recognize this.
+const wrapperScript = `#!/bin/sh
+FENCE="${HOOP_FENCE_BIN:-}"
+if [ -z "$FENCE" ]; then
+  FENCE="$(command -v fence 2>/dev/null)"
+fi
+exec "$FENCE" hook claude-code "$@"
+`
+
+// A sibling plugin hook that rewrites commands for a different tool. It is a
+// PreToolUse hook in the same file and must never read as Fence.
+const foreignScript = `#!/bin/sh
+# runs before fence does, but is not fence
+exec "$JULIUS" hook claude pre
+`
+
+type pluginFixture struct {
+	name    string // key in installed_plugins.json and enabledPlugins
+	hooks   string // hooks/hooks.json contents; "" writes no file
+	script  string // scripts/hook.sh contents; "" writes no file
+	noEntry bool   // omit from installed_plugins.json entirely
+}
+
+// writePluginHome builds a fake ~/.claude/plugins tree and points HOME at it.
+func writePluginHome(t *testing.T, fixtures ...pluginFixture) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	root := filepath.Join(home, ".claude", "plugins")
+
+	installed := installedPlugins{Plugins: map[string][]struct {
+		InstallPath string `json:"installPath"`
+	}{}}
+	for _, f := range fixtures {
+		dir := filepath.Join(root, "cache", f.name, "1.0.0")
+		if f.hooks != "" {
+			writeTestFile(t, filepath.Join(dir, "hooks", "hooks.json"), f.hooks)
+		}
+		if f.script != "" {
+			writeTestFile(t, filepath.Join(dir, "scripts", "hook.sh"), f.script)
+		}
+		if f.noEntry {
+			continue
+		}
+		installed.Plugins[f.name] = []struct {
+			InstallPath string `json:"installPath"`
+		}{{InstallPath: dir}}
+	}
+	data, err := json.Marshal(installed)
+	if err != nil {
+		t.Fatalf("marshal installed_plugins: %v", err)
+	}
+	writeTestFile(t, filepath.Join(root, "installed_plugins.json"), string(data))
+}
+
+// preToolUse builds a hooks.json declaring one PreToolUse command.
+func preToolUse(command string) string {
+	return `{"hooks":{"PreToolUse":[{"matcher":"` + toolMatcher +
+		`","hooks":[{"type":"command","command":"` + command + `"}]}]}}`
+}
+
+func enabledScope(name string, on bool) map[string]any {
+	return map[string]any{"enabledPlugins": map[string]any{name: on}}
+}
+
+func TestFindPluginHookProvider(t *testing.T) {
+	const plugin = "hoop@hooplabs"
+	const wrapperCmd = "${CLAUDE_PLUGIN_ROOT}/scripts/hook.sh"
+
+	tests := []struct {
+		name    string
+		fixture pluginFixture
+		scopes  []map[string]any
+		agent   hookAgent
+		want    bool
+	}{
+		{
+			// The case that shipped the bug: a wrapper script, invoked through
+			// the plugin root, that execs Fence.
+			name:    "wrapper script running fence",
+			fixture: pluginFixture{name: plugin, hooks: preToolUse(wrapperCmd), script: wrapperScript},
+			scopes:  []map[string]any{enabledScope(plugin, true)},
+			want:    true,
+		},
+		{
+			name:    "plugin invoking fence directly",
+			fixture: pluginFixture{name: plugin, hooks: preToolUse("/opt/homebrew/bin/fence hook claude-code")},
+			scopes:  []map[string]any{enabledScope(plugin, true)},
+			want:    true,
+		},
+		{
+			name:    "quiet flag on a direct invocation still counts",
+			fixture: pluginFixture{name: plugin, hooks: preToolUse("fence hook claude-code --quiet")},
+			scopes:  []map[string]any{enabledScope(plugin, true)},
+			want:    true,
+		},
+		// Everything below must NOT report a provider: a false positive makes
+		// init skip the hook and leaves the user unguarded.
+		{
+			name:    "plugin explicitly disabled",
+			fixture: pluginFixture{name: plugin, hooks: preToolUse(wrapperCmd), script: wrapperScript},
+			scopes:  []map[string]any{enabledScope(plugin, false)},
+			want:    false,
+		},
+		{
+			name:    "plugin never enabled",
+			fixture: pluginFixture{name: plugin, hooks: preToolUse(wrapperCmd), script: wrapperScript},
+			scopes:  nil,
+			want:    false,
+		},
+		{
+			// A project scope turning the plugin off wins over the user scope.
+			name:    "disabled by the more specific scope",
+			fixture: pluginFixture{name: plugin, hooks: preToolUse(wrapperCmd), script: wrapperScript},
+			scopes:  []map[string]any{enabledScope(plugin, true), enabledScope(plugin, false)},
+			want:    false,
+		},
+		{
+			name:    "another plugin's PreToolUse hook",
+			fixture: pluginFixture{name: plugin, hooks: preToolUse(wrapperCmd), script: foreignScript},
+			scopes:  []map[string]any{enabledScope(plugin, true)},
+			want:    false,
+		},
+		{
+			name:    "script running some other tool's claude-code hook",
+			fixture: pluginFixture{name: plugin, hooks: preToolUse(wrapperCmd), script: "#!/bin/sh\nexec \"$OTHER\" hook claude-code\n"},
+			scopes:  []map[string]any{enabledScope(plugin, true)},
+			want:    false,
+		},
+		{
+			name:    "hook command with shell syntax is not resolved",
+			fixture: pluginFixture{name: plugin, hooks: preToolUse("sh -c '${CLAUDE_PLUGIN_ROOT}/scripts/hook.sh | tee /tmp/x'"), script: wrapperScript},
+			scopes:  []map[string]any{enabledScope(plugin, true)},
+			want:    false,
+		},
+		{
+			name:    "script outside the plugin root",
+			fixture: pluginFixture{name: plugin, hooks: preToolUse("/usr/local/bin/hook.sh"), script: wrapperScript},
+			scopes:  []map[string]any{enabledScope(plugin, true)},
+			want:    false,
+		},
+		{
+			// Only PreToolUse duplication matters — a banner hook is not what
+			// makes Fence evaluate twice.
+			name: "fence hook only on SessionStart",
+			fixture: pluginFixture{name: plugin, script: wrapperScript,
+				hooks: `{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/scripts/hook.sh session-start"}]}]}}`},
+			scopes: []map[string]any{enabledScope(plugin, true)},
+			want:   false,
+		},
+		{
+			name:    "plugin ships no hooks file",
+			fixture: pluginFixture{name: plugin, script: wrapperScript},
+			scopes:  []map[string]any{enabledScope(plugin, true)},
+			want:    false,
+		},
+		{
+			name:    "unparseable hooks file",
+			fixture: pluginFixture{name: plugin, hooks: "{not json", script: wrapperScript},
+			scopes:  []map[string]any{enabledScope(plugin, true)},
+			want:    false,
+		},
+		{
+			name:    "wrapper command names a script the plugin never shipped",
+			fixture: pluginFixture{name: plugin, hooks: preToolUse(wrapperCmd)},
+			scopes:  []map[string]any{enabledScope(plugin, true)},
+			want:    false,
+		},
+		{
+			name:    "plugin missing from installed_plugins.json",
+			fixture: pluginFixture{name: plugin, hooks: preToolUse(wrapperCmd), script: wrapperScript, noEntry: true},
+			scopes:  []map[string]any{enabledScope(plugin, true)},
+			want:    false,
+		},
+		{
+			// Codex has no plugin layer, so its hooks can never come from one.
+			name:    "agent without a plugin system",
+			fixture: pluginFixture{name: plugin, hooks: preToolUse(wrapperCmd), script: wrapperScript},
+			scopes:  []map[string]any{enabledScope(plugin, true)},
+			agent:   hookAgents[1],
+			want:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			writePluginHome(t, tc.fixture)
+			agent := tc.agent
+			if agent.name == "" {
+				agent = hookAgents[0]
+			}
+			provider, got := findPluginHookProvider(agent, tc.scopes...)
+			if got != tc.want {
+				t.Fatalf("findPluginHookProvider = %v (%s), want %v", got, provider.name, tc.want)
+			}
+			if got && provider.name != plugin {
+				t.Errorf("provider name = %q, want %q", provider.name, plugin)
+			}
+		})
+	}
+}
+
+// TestFindPluginHookProviderNoPluginsDir pins the fresh-machine case: no
+// plugins installed at all must simply mean no provider, not an error path
+// that could be mistaken for one.
+func TestFindPluginHookProviderNoPluginsDir(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if _, found := findPluginHookProvider(hookAgents[0]); found {
+		t.Fatal("reported a provider with no plugins installed")
+	}
+}
+
+func TestInstallStatusLineOnly(t *testing.T) {
+	const foreignLine = "/usr/local/bin/my-statusline"
+
+	tests := []struct {
+		name      string
+		initial   string
+		want      hookInstallResult
+		wantNote  bool
+		preCmds   []string
+		slCommand string
+	}{
+		{
+			name:      "installs only the status line on a fresh file",
+			want:      hookInstalled,
+			slCommand: wantStatusCommand,
+		},
+		{
+			// The dedup that motivates all of this: a hook left by an earlier
+			// init, now redundant with the plugin's, is removed.
+			name: "removes a duplicate hook an earlier init left",
+			initial: `{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"` + wantCommand + `"}]}]},
+				"statusLine":{"type":"command","command":"` + wantStatusCommand + `"}}`,
+			want:      hookUpdated,
+			slCommand: wantStatusCommand,
+		},
+		{
+			name:      "removes the banner hook too",
+			initial:   `{"hooks":{"SessionStart":[{"matcher":"startup","hooks":[{"type":"command","command":"` + wantSessionCommand + `"}]}]}}`,
+			want:      hookInstalled,
+			slCommand: wantStatusCommand,
+		},
+		{
+			name:      "idempotent once converged",
+			initial:   `{"statusLine":{"type":"command","command":"` + wantStatusCommand + `"}}`,
+			want:      hookUnchanged,
+			slCommand: wantStatusCommand,
+		},
+		{
+			// Nothing left to contribute: the plugin runs the hook and the
+			// user owns the status line.
+			name:      "leaves a foreign status line alone and adds nothing",
+			initial:   `{"statusLine":{"type":"command","command":"` + foreignLine + `"}}`,
+			want:      hookUnchanged,
+			wantNote:  true,
+			slCommand: foreignLine,
+		},
+		{
+			name: "hooks of other tools survive",
+			initial: `{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[
+				{"type":"command","command":"` + wantCommand + `"},
+				{"type":"command","command":"/usr/local/bin/other hook claude"}]}]}}`,
+			want:      hookInstalled,
+			preCmds:   []string{"/usr/local/bin/other hook claude"},
+			slCommand: wantStatusCommand,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// HOME isolation keeps the developer's own status line out of the
+			// occupancy check.
+			t.Setenv("HOME", t.TempDir())
+			path := filepath.Join(t.TempDir(), ".claude", "settings.json")
+			if tc.initial != "" {
+				writeTestFile(t, path, tc.initial)
+			}
+
+			got, note, err := installStatusLineHooks(path, hookAgents[0], testSpecs(false), wantStatusCommand, false, true)
+			if err != nil {
+				t.Fatalf("installStatusLineHooks: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("result = %v, want %v", got, tc.want)
+			}
+			if (note != "") != tc.wantNote {
+				t.Errorf("note = %q, wantNote %v", note, tc.wantNote)
+			}
+			if tc.initial == "" && tc.want == hookUnchanged {
+				return
+			}
+			if sl := statusLineCommandOf(t, path); sl != tc.slCommand {
+				t.Errorf("statusLine = %q, want %q", sl, tc.slCommand)
+			}
+			gotPre := hookCommands(t, path, "PreToolUse")
+			if len(gotPre) != len(tc.preCmds) {
+				t.Fatalf("PreToolUse = %v, want %v", gotPre, tc.preCmds)
+			}
+			for i, want := range tc.preCmds {
+				if gotPre[i] != want {
+					t.Errorf("PreToolUse[%d] = %q, want %q", i, gotPre[i], want)
+				}
+			}
+			if session := hookCommands(t, path, "SessionStart"); len(session) != 0 {
+				t.Errorf("SessionStart = %v, want none", session)
+			}
+		})
+	}
+}
+
+func TestRemoveHooksOnlyKeepsStatusLine(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	writeTestFile(t, path, `{"hooks":{
+		"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"`+wantCommand+`"}]}],
+		"SessionStart":[{"matcher":"startup","hooks":[{"type":"command","command":"`+wantSessionCommand+`"}]}]},
+		"statusLine":{"type":"command","command":"`+wantStatusCommand+`"},
+		"model":"opus"}`)
+
+	got, err := removeHooks(path, claudeInvocation, true)
+	if err != nil || got != hookRemoved {
+		t.Fatalf("removeHooks = %v, %v; want hookRemoved, nil", got, err)
+	}
+
+	settings := readSettings(t, path)
+	if _, present := settings["hooks"]; present {
+		t.Errorf("hooks key survived: %v", settings["hooks"])
+	}
+	if cmd := statusLineCommandOf(t, path); cmd != wantStatusCommand {
+		t.Errorf("statusLine = %q, want it kept as %q", cmd, wantStatusCommand)
+	}
+	if settings["model"] != "opus" {
+		t.Errorf("unrelated settings lost: %v", settings)
+	}
+}
+
+// TestRemoveHooksOnlyWithNothingButStatusLine pins that --hooks-only does not
+// report a removal when only the status line is present: it is not a hook, and
+// claiming otherwise would tell the user Fence was disarmed when it wasn't.
+func TestRemoveHooksOnlyWithNothingButStatusLine(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	writeTestFile(t, path, `{"statusLine":{"type":"command","command":"`+wantStatusCommand+`"}}`)
+
+	got, err := removeHooks(path, claudeInvocation, true)
+	if err != nil || got != hookAbsent {
+		t.Fatalf("removeHooks = %v, %v; want hookAbsent, nil", got, err)
+	}
+	if cmd := statusLineCommandOf(t, path); cmd != wantStatusCommand {
+		t.Errorf("statusLine = %q, want it kept", cmd)
+	}
+}

--- a/internal/cli/plugins_test.go
+++ b/internal/cli/plugins_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -218,6 +219,92 @@ func TestFindPluginHookProviderNoPluginsDir(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	if _, found := findPluginHookProvider(hookAgents[0]); found {
 		t.Fatal("reported a provider with no plugins installed")
+	}
+}
+
+// TestHookAlreadyProvided pins the scope policy around standing down. The
+// guard-gap scenario is the load-bearing case: plugin enablement is per-scope,
+// so a global install must never stand down (the user scope enabling the
+// plugin proves nothing about every project), and a project whose local
+// settings disable the plugin must still get the hook.
+func TestHookAlreadyProvided(t *testing.T) {
+	const plugin = "hoop@hooplabs"
+	enabled := `{"enabledPlugins":{"` + plugin + `":true}}`
+	disabled := `{"enabledPlugins":{"` + plugin + `":false}}`
+
+	tests := []struct {
+		name   string
+		user   string // ~/.claude/settings.json ("" = absent)
+		target string // the settings file init writes ("" = absent)
+		local  string // settings.local.json beside the target ("" = absent)
+		global bool
+		want   bool
+	}{
+		{
+			name: "project init stands down when the user scope enables the plugin",
+			user: enabled,
+			want: true,
+		},
+		{
+			// The guard gap: global init covers projects this function cannot
+			// see, any of which may disable the plugin — never stand down.
+			name:   "global init never stands down",
+			user:   enabled,
+			target: enabled,
+			global: true,
+			want:   false,
+		},
+		{
+			name:   "project settings disabling the plugin means no provider",
+			user:   enabled,
+			target: disabled,
+			want:   false,
+		},
+		{
+			name:  "settings.local.json disabling the plugin means no provider",
+			user:  enabled,
+			local: disabled,
+			want:  false,
+		},
+		{
+			name:   "target re-enabling over a user-scope disable stands down",
+			user:   disabled,
+			target: enabled,
+			want:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			writePluginHome(t, pluginFixture{
+				name:   plugin,
+				hooks:  preToolUse("${CLAUDE_PLUGIN_ROOT}/scripts/hook.sh"),
+				script: wrapperScript,
+			})
+			home := os.Getenv("HOME")
+			if tc.user != "" {
+				writeTestFile(t, filepath.Join(home, ".claude", "settings.json"), tc.user)
+			}
+			dir := t.TempDir()
+			path := filepath.Join(dir, ".claude", "settings.json")
+			if tc.global {
+				path = filepath.Join(home, ".claude", "settings.json")
+			}
+			if tc.target != "" && !tc.global {
+				writeTestFile(t, path, tc.target)
+			}
+			if tc.local != "" {
+				writeTestFile(t, filepath.Join(filepath.Dir(path), "settings.local.json"), tc.local)
+			}
+
+			got, note := hookAlreadyProvided(hookAgents[0], path, tc.global)
+			if got != tc.want {
+				t.Fatalf("hookAlreadyProvided = %v, want %v", got, tc.want)
+			}
+			if got && note == "" {
+				t.Error("standing down must explain itself in the note")
+			}
+		})
 	}
 }
 

--- a/internal/cli/statusline.go
+++ b/internal/cli/statusline.go
@@ -13,10 +13,18 @@ import (
 // replaces. When another status line is configured, in this file or a scope
 // that interacts with it, Fence leaves it untouched and falls back to the
 // SessionStart banner spec; the returned note tells the user why.
-func installStatusLineHooks(path string, agent hookAgent, specs []hookSpec, slCommand string, global bool) (hookInstallResult, string, error) {
+//
+// skipHooks hands the hook surface to whatever already runs it (a plugin, or
+// the user's own arrangement under --statusline-only) and reduces the install
+// to the status line alone.
+func installStatusLineHooks(path string, agent hookAgent, specs []hookSpec, slCommand string, global, skipHooks bool) (hookInstallResult, string, error) {
 	settings, err := loadSettings(path)
 	if err != nil {
 		return hookUnchanged, "", err
+	}
+
+	if skipHooks {
+		return installStatusLineOnly(path, settings, agent, slCommand, global)
 	}
 
 	pre, session := specs[0], specs[1]
@@ -52,6 +60,46 @@ func installStatusLineHooks(path string, agent hookAgent, specs []hookSpec, slCo
 		return hookUnchanged, "", nil
 	}
 	return result, "", saveSettings(path, settings)
+}
+
+// installStatusLineOnly contributes just the status line: the one piece of a
+// Fence install a plugin cannot supply, since statusLine is a settings-only
+// field. Any Fence hooks a previous init left in this file are removed on the
+// way through — that duplicate is exactly what makes Fence run twice per tool
+// call, and leaving it would defeat the point of standing down. When the
+// status line slot belongs to someone else there is nothing left to
+// contribute, and the note says so rather than reporting a hollow success.
+func installStatusLineOnly(path string, settings map[string]any, agent hookAgent, slCommand string, global bool) (hookInstallResult, string, error) {
+	result := hookUnchanged
+	hooks := asMap(settings["hooks"])
+	for _, event := range []string{"PreToolUse", "SessionStart"} {
+		if removeEventHooks(hooks, event, agent.invocation) {
+			result = max(result, hookUpdated)
+		}
+	}
+	if result != hookUnchanged && len(hooks) == 0 {
+		delete(settings, "hooks")
+	}
+
+	note := ""
+	if takenAt, taken := statusLineTaken(path, settings, global, agent.invocation); taken {
+		// Ours would shadow theirs, so it goes; the hook still guards the
+		// session, it just no longer announces itself here.
+		if cmd, ok := asMap(settings["statusLine"])["command"].(string); ok && containsHook(cmd, agent.invocation) {
+			delete(settings, "statusLine")
+			result = max(result, hookUpdated)
+		}
+		note = fmt.Sprintf("A status line is already configured (%s) — left untouched, so Fence adds nothing here.\n"+
+			"To show Fence there too, have your statusline command append the output of `%s statusline`.",
+			takenAt, agent.invocation)
+	} else {
+		result = max(result, convergeStatusLine(settings, agent.invocation, slCommand))
+	}
+
+	if result == hookUnchanged {
+		return hookUnchanged, note, nil
+	}
+	return result, note, saveSettings(path, settings)
 }
 
 // convergeStatusLine points the settings' statusLine entry at command.

--- a/internal/cli/statusline_test.go
+++ b/internal/cli/statusline_test.go
@@ -15,7 +15,7 @@ const wantStatusCommand = wantCommand + " statusline"
 // ~/.claude/settings.json can't leak into the occupancy check.
 func installStatus(t *testing.T, path string, quiet, global bool) (hookInstallResult, string, error) {
 	t.Helper()
-	return installStatusLineHooks(path, hookAgents[0], testSpecs(quiet), wantStatusCommand, global)
+	return installStatusLineHooks(path, hookAgents[0], testSpecs(quiet), wantStatusCommand, global, false)
 }
 
 func statusLineCommandOf(t *testing.T, path string) string {
@@ -310,7 +310,7 @@ func TestRemoveHooksStatusLineRoundTrip(t *testing.T) {
 	if _, _, err := installStatus(t, path, false, false); err != nil {
 		t.Fatalf("installStatusLineHooks: %v", err)
 	}
-	if got, err := removeHooks(path, claudeInvocation); err != nil || got != hookRemoved {
+	if got, err := removeHooks(path, claudeInvocation, false); err != nil || got != hookRemoved {
 		t.Fatalf("removeHooks = %v, %v; want hookRemoved, nil", got, err)
 	}
 
@@ -330,7 +330,7 @@ func TestRemoveHooksRemovesFenceStatusLine(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "settings.json")
 	writeTestFile(t, path, `{"model":"opus","statusLine":{"type":"command","command":"`+wantStatusCommand+`"}}`)
 
-	if got, err := removeHooks(path, claudeInvocation); err != nil || got != hookRemoved {
+	if got, err := removeHooks(path, claudeInvocation, false); err != nil || got != hookRemoved {
 		t.Fatalf("removeHooks = %v, %v; want hookRemoved, nil", got, err)
 	}
 	settings := readSettings(t, path)
@@ -348,7 +348,7 @@ func TestRemoveHooksKeepsForeignStatusLine(t *testing.T) {
 	initial := `{"statusLine":{"type":"command","command":"~/.claude/statusline.sh"}}`
 	writeTestFile(t, path, initial)
 
-	if got, err := removeHooks(path, claudeInvocation); err != nil || got != hookAbsent {
+	if got, err := removeHooks(path, claudeInvocation, false); err != nil || got != hookAbsent {
 		t.Fatalf("removeHooks = %v, %v; want hookAbsent, nil", got, err)
 	}
 	data, err := os.ReadFile(path)

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -8,7 +8,10 @@ import (
 )
 
 func newUninstallCommand() *cobra.Command {
-	var global bool
+	var (
+		global    bool
+		hooksOnly bool
+	)
 
 	cmd := &cobra.Command{
 		Use:   "uninstall [agent]",
@@ -19,6 +22,9 @@ func newUninstallCommand() *cobra.Command {
 			"opencode (whose generated plugin file is deleted instead). By default it\n" +
 			"edits the project settings (./.claude, ./.codex or ./.opencode); use\n" +
 			"--global for the user-level file under ~.\n\n" +
+			"Use --hooks-only to remove just the hooks and keep Fence's status line —\n" +
+			"what you want when a plugin runs the hook, since no plugin can provide a\n" +
+			"status line.\n\n" +
 			"Rulepacks installed with `fence add` are not touched — remove those with\n" +
 			"`fence remove <pack>`.",
 		Args: cobra.MaximumNArgs(1),
@@ -26,6 +32,9 @@ func newUninstallCommand() *cobra.Command {
 			agent, err := resolveAgent(args)
 			if err != nil {
 				return fail(cmd, err)
+			}
+			if hooksOnly && agent.plugin {
+				return fail(cmd, fmt.Errorf("--hooks-only doesn't apply to %s: its hooks and banner live in one generated plugin file", agent.display))
 			}
 			var path string
 			var result hookRemoveResult
@@ -35,15 +44,18 @@ func newUninstallCommand() *cobra.Command {
 				}
 			} else {
 				if path, err = settingsPath(agent, global); err == nil {
-					result, err = removeHooks(path, agent.invocation)
+					result, err = removeHooks(path, agent.invocation, hooksOnly)
 				}
 			}
 			if err != nil {
 				return fail(cmd, err)
 			}
 			what := "hooks"
-			if agent.plugin {
+			switch {
+			case agent.plugin:
 				what = "plugin"
+			case hooksOnly:
+				what = "hooks (status line kept)"
 			}
 			switch result {
 			case hookRemoved:
@@ -57,6 +69,7 @@ func newUninstallCommand() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&global, "global", false, "remove from the user-level settings under ~ instead of the project")
+	cmd.Flags().BoolVar(&hooksOnly, "hooks-only", false, "remove the hooks but keep Fence's status line")
 	return cmd
 }
 
@@ -77,7 +90,12 @@ const (
 // itself), so init followed by uninstall leaves the settings as they were.
 // Everything else is preserved — a status line that is not Fence's above all
 // — and when there is nothing to remove the file is not rewritten, or created.
-func removeHooks(path, invocation string) (hookRemoveResult, error) {
+//
+// hooksOnly keeps Fence's own status line in place. The two are separable
+// because they can have different owners: a plugin can run the hook, but
+// statusLine is a settings-only field no plugin can declare, so removing a
+// duplicate hook must not cost the user their status line.
+func removeHooks(path, invocation string, hooksOnly bool) (hookRemoveResult, error) {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		return hookAbsent, nil
 	}
@@ -95,9 +113,11 @@ func removeHooks(path, invocation string) (hookRemoveResult, error) {
 		delete(settings, "hooks")
 	}
 
-	if cmd, ok := asMap(settings["statusLine"])["command"].(string); ok && containsHook(cmd, invocation) {
-		delete(settings, "statusLine")
-		removed = true
+	if !hooksOnly {
+		if cmd, ok := asMap(settings["statusLine"])["command"].(string); ok && containsHook(cmd, invocation) {
+			delete(settings, "statusLine")
+			removed = true
+		}
 	}
 
 	if !removed {

--- a/internal/cli/uninstall_test.go
+++ b/internal/cli/uninstall_test.go
@@ -78,7 +78,7 @@ func TestRemoveHooks(t *testing.T) {
 				writeTestFile(t, path, tt.initial)
 			}
 
-			got, err := removeHooks(path, claudeInvocation)
+			got, err := removeHooks(path, claudeInvocation, false)
 			if err != nil {
 				t.Fatalf("removeHooks: %v", err)
 			}
@@ -114,7 +114,7 @@ func TestRemoveHooksRoundTrip(t *testing.T) {
 	if _, err := installHooks(path, testSpecs(false)); err != nil {
 		t.Fatalf("installHooks: %v", err)
 	}
-	if got, err := removeHooks(path, claudeInvocation); err != nil || got != hookRemoved {
+	if got, err := removeHooks(path, claudeInvocation, false); err != nil || got != hookRemoved {
 		t.Fatalf("removeHooks = %v, %v; want hookRemoved, nil", got, err)
 	}
 
@@ -139,7 +139,7 @@ func TestRemoveHooksKeepsNonMapHooksKey(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "settings.json")
 	writeTestFile(t, path, `{"hooks":"keep","statusLine":{"type":"command","command":"`+wantCommand+` statusline"}}`)
 
-	if got, err := removeHooks(path, claudeInvocation); err != nil || got != hookRemoved {
+	if got, err := removeHooks(path, claudeInvocation, false); err != nil || got != hookRemoved {
 		t.Fatalf("removeHooks = %v, %v; want hookRemoved, nil", got, err)
 	}
 	settings := readSettings(t, path)
@@ -158,7 +158,7 @@ func TestRemoveHooksNoOpDoesNotRewrite(t *testing.T) {
 	initial := `{"model":"opus","hooks":{"PostToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"echo hi"}]}]}}`
 	writeTestFile(t, path, initial)
 
-	if got, err := removeHooks(path, claudeInvocation); err != nil || got != hookAbsent {
+	if got, err := removeHooks(path, claudeInvocation, false); err != nil || got != hookAbsent {
 		t.Fatalf("removeHooks = %v, %v; want hookAbsent, nil", got, err)
 	}
 	data, err := os.ReadFile(path)
@@ -173,7 +173,7 @@ func TestRemoveHooksNoOpDoesNotRewrite(t *testing.T) {
 func TestRemoveHooksRejectsInvalidJSON(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "settings.json")
 	writeTestFile(t, path, "{not json")
-	if _, err := removeHooks(path, claudeInvocation); err == nil {
+	if _, err := removeHooks(path, claudeInvocation, false); err == nil {
 		t.Fatal("expected an error for invalid JSON, got nil")
 	}
 }


### PR DESCRIPTION
Fixes [ATR-167](https://linear.app/hoophq/issue/ATR-167) and [ATR-168](https://linear.app/hoophq/issue/ATR-168).

## The bug

A Claude Code plugin can register a Fence PreToolUse hook of its own — the hoop plugin ships one (`hooks/hooks.json` → `scripts/fence-hook.sh`, same matcher as ours). On a machine with both the plugin and a `fence init` install, Fence ran **twice per tool call**: measured on 12 of 13 matching tool calls in a real session (~17ms direct + ~31ms via the plugin's shim), with every `🚧 Fence allowed this` notice printed twice. Verdicts stay correct; the cost is latency, doubled chat noise, and a user who reasonably concludes Fence is broken.

## The fix — one hook per agent (ATR-167)

`fence init` now detects an enabled plugin whose PreToolUse hook runs Fence and contributes only the status line — the piece no plugin can supply, since `statusLine` is a settings-only field. A duplicate hook left by an earlier init is removed on the way through, so re-running init heals an already-doubled machine:

```
$ fence init
Updated the Fence status line in .claude/settings.json
The hoop@hooplabs plugin already provides the Fence hook, so only the status line was
installed here — a second hook would evaluate every tool call twice.
Use --force-hooks to install Fence's own hook anyway.
```

Detection recognizes both a direct `fence hook claude-code` command and a wrapper script under `${CLAUDE_PLUGIN_ROOT}` that invokes Fence (the hoop plugin's shape — the binary only appears there through a variable, so `containsHook` alone can't see it; we resolve and read the script).

**Detection fails toward installing.** A false negative merely duplicates work; a false positive would skip the hook and leave the user unguarded while init reports success — the one outcome Fence must never produce. So every uncertainty resolves to "install it": unreadable/unparseable files, a plugin present but not explicitly enabled, a project scope disabling what the user scope enabled, shell syntax in the hook command, a script outside the plugin root, a Fence hook only on SessionStart. Each of these is a pinned test case.

## Separate ownership (ATR-168)

The hook and the status line can have different owners now, via supported commands instead of hand-editing:

- `fence uninstall --hooks-only` — removes the hooks, keeps Fence's status line. Previously uninstall took both, so users following the hoop doctor's "run `fence uninstall`" advice silently lost their status line.
- `fence init --statusline-only` — writes just the status line.
- `fence init --force-hooks` — installs our hook even beside a plugin's.

`--hooks-only` is rejected for OpenCode, whose hooks and banner live in one generated plugin file.

## Verification

- `go test ./...` green, `go vet` and `gofmt` clean; new table-driven tests cover 16 detection cases (3 positive, 13 false-positive guards) plus statusline-only install and hooks-only removal.
- End-to-end against the real hoop plugin install: fresh init (skips hook, notes why), idempotent re-run, `--force-hooks`, plain init healing a forced duplicate, `--hooks-only` keeping the status line, no-plugin machine still getting the hook, and Codex unaffected.

Codex and OpenCode behavior is unchanged — neither has a plugin layer that could provide the hook.

Companion PR: [hoophq/claude-marketplace#6](https://github.com/hoophq/claude-marketplace/pull/6) (ATR-169) fixes the plugin-side doctor false positive and adds `HOOP_FENCE_DISABLE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)