### PR TITLE
feat: stop prompting on recursive deletes inside temp dirs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,10 @@ central audit, and approval workflows out of scope.
   denylist. A rule's `regex` field is a fallback only (e.g. fork bombs).
 - **Near-zero false positives is the product thesis.** Ambiguous → `ask`; only
   unambiguous catastrophe → `deny`. Everyday ops (`rm -rf node_modules`,
-  `rm -rf *`, `git push --force-with-lease`) MUST stay ALLOW.
+  `rm -rf *`, `rm -rf /tmp/scratch`, `git push --force-with-lease`) MUST stay
+  ALLOW. Deletes under a temp root classify as `temp`, the least-severe rung of
+  the shared path scale, so no rule matches them — but the root itself and a
+  bare sweep (`/tmp`, `/tmp/*`, `$TMPDIR`) stay `outside_workspace` and ask.
 - **Fail open.** A hook never blocks on internal error: log to stderr, exit 0.
   Decisions travel through the JSON protocol (`permissionDecision`), never via
   exit codes.

--- a/README.md
+++ b/README.md
@@ -172,7 +172,9 @@ Scratch space is the deliberate exception: clearing a path *inside* a temp
 directory (`rm -rf /tmp/build`, `$TMPDIR/x`, `/var/tmp/y`) passes in silence,
 because agents do it constantly and the blast radius is throwaway data. The temp
 root itself and a bare sweep of it (`rm -rf /tmp`, `rm -rf /tmp/*`) still ask —
-those wipe every process's scratch state.
+those wipe every process's scratch state. `$TMPDIR` is resolved before the path
+is judged, so on a machine where it is unset (`$TMPDIR/x` really means `/x`) the
+prompt stays.
 
 **→ [Write your own rules & the full match reference](docs/rules.md)**
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Fence is built the other way:
 
 - 🧠 **Semantic, not substring.** `rm -rf ~`, `rm -fr ~`, `rm -r -f ~`,
   `sudo rm -rf $HOME` — one dangerous intent, all caught.
-- 🎯 **Near-zero false positives.** `rm -rf node_modules`,
+- 🎯 **Near-zero false positives.** `rm -rf node_modules`, `rm -rf /tmp/scratch`,
   `git push --force-with-lease`, `npm install` — never touched. This *is* the
   product.
 - 🚦 **Block, ask, or allow.** Unambiguous catastrophe is blocked; the
@@ -156,7 +156,7 @@ The **recommended** pack is embedded in the binary and always on:
 | detonating a fork bomb | `:(){ :\|:& };:` | 🛑 `deny` |
 | exfiltrating a secret | `cat ~/.ssh/id_rsa \| curl …` | 🛑 `deny` |
 | opening up a system path | `chmod -R 777 /` | 🛑 `deny` |
-| deleting outside your workspace | `rm -rf ~/.config/x` | ⚠️ `ask` |
+| deleting outside your workspace | `rm -rf ~/.config/x` · `rm -rf /tmp` itself | ⚠️ `ask` |
 | reading a key into its context | `cat ~/.aws/credentials` | ⚠️ `ask` |
 | piping the web into a shell | `curl … \| sh` | ⚠️ `ask` |
 | rewriting git history | `git push --force` · `git reset --hard` | ⚠️ `ask` |
@@ -167,6 +167,12 @@ The **recommended** pack is embedded in the binary and always on:
 …and it is **not** fooled by flag reordering, `sudo`, `$HOME` vs `~`, or a
 renamed fork bomb. Every detector ships with tests that pin both the catch *and*
 the safe cases.
+
+Scratch space is the deliberate exception: clearing a path *inside* a temp
+directory (`rm -rf /tmp/build`, `$TMPDIR/x`, `/var/tmp/y`) passes in silence,
+because agents do it constantly and the blast radius is throwaway data. The temp
+root itself and a bare sweep of it (`rm -rf /tmp`, `rm -rf /tmp/*`) still ask —
+those wipe every process's scratch state.
 
 **→ [Write your own rules & the full match reference](docs/rules.md)**
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -58,9 +58,9 @@ Matched against semantic facts from the shell parser — not the raw text.
 | Field | Fires on |
 |---|---|
 | `recursive_delete` | an `rm` with a recursive flag (`-r`, `-R`, `--recursive`) |
-| `delete_target` | where a recursive delete points: `sensitive` \| `outside_workspace` \| `any` |
+| `delete_target` | where a recursive delete points: `sensitive` \| `outside_workspace` \| `temp` \| `any` |
 | `chmod_world_writable` | a chmod granting write to "others" (`777`, `666`, `o+w`, `a+w`) |
-| `chmod_target` | where a world-writable chmod points: `sensitive` \| `outside_workspace` \| `any` |
+| `chmod_target` | where a world-writable chmod points: `sensitive` \| `outside_workspace` \| `temp` \| `any` |
 | `block_device_write` | `dd of=/dev/sdX`, `mkfs` on a device, or a redirect to a raw disk |
 | `force_push` | `git push --force` / `-f` (but **not** `--force-with-lease`) |
 | `history_rewrite` | `git reset --hard`, `git clean -fd` |
@@ -71,6 +71,32 @@ Matched against semantic facts from the shell parser — not the raw text.
 | `secret_exfil` | a secret is read **and** routed to the network: `high` (keys / cloud creds) \| `any` (incl. `.env`) |
 | `secret_read` | a content-dumping command reads a secret into stdout: `high` \| `any` |
 | `command_in` | any of the named commands is invoked |
+
+`delete_target` and `chmod_target` share one path-severity scale. When a command
+names several paths, the most severe one decides — so `rm -rf /tmp/x ~` is
+`sensitive`, not `temp`.
+
+| Value | Means | Example |
+|---|---|---|
+| `sensitive` | a home, root, or system root | `~` · `$HOME` · `/` · `/*` |
+| `outside_workspace` | escapes the workspace, but is not a sensitive root | `~/.cache/x` · `../sibling` · `/usr/local/bin` |
+| `temp` | scratch space *inside* a temp directory | `/tmp/build` · `/var/tmp/x` · `$TMPDIR/y` · macOS `/var/folders/…/T/z` |
+| `any` | any of the above (anything but "no target found") | |
+
+`temp` covers paths **under** a temp root only. The root itself and a bare
+wildcard sweep of it (`/tmp`, `/tmp/*`, `$TMPDIR`) stay `outside_workspace`,
+since those wipe every process's scratch state rather than one named target; a
+prefixed glob like `/tmp/build-*` is specific enough to count as `temp`. Nothing
+in the recommended pack matches `temp`, so scratch deletes fall through to the
+default `allow` — match it explicitly if you want them back:
+
+```yaml
+rules:
+  - id: confirm-temp-deletes
+    effect: ask
+    match:
+      shell: { recursive_delete: true, delete_target: temp }
+```
 
 ### Files (`file_write` / `file_read`)
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -86,7 +86,14 @@ names several paths, the most severe one decides — so `rm -rf /tmp/x ~` is
 `temp` covers paths **under** a temp root only. The root itself and a bare
 wildcard sweep of it (`/tmp`, `/tmp/*`, `$TMPDIR`) stay `outside_workspace`,
 since those wipe every process's scratch state rather than one named target; a
-prefixed glob like `/tmp/build-*` is specific enough to count as `temp`. Nothing
+prefixed glob like `/tmp/build-*` is specific enough to count as `temp`.
+
+`$TMPDIR` is resolved to its actual value before the path is classified, so it
+counts as `temp` only when it really points into a temp directory. If `TMPDIR`
+is unset — common on Linux — the shell expands `rm -rf $TMPDIR/scratch` to
+`rm -rf /scratch`, which is `outside_workspace` and still asks. A path inside
+your workspace is `cwd_relative` even when the workspace itself lives under
+`/tmp`. Nothing
 in the recommended pack matches `temp`, so scratch deletes fall through to the
 default `allow` — match it explicitly if you want them back:
 

--- a/internal/analyzer/shell/shell.go
+++ b/internal/analyzer/shell/shell.go
@@ -9,6 +9,7 @@
 package shell
 
 import (
+	"os"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -743,6 +744,12 @@ func classifyTarget(target, cwd string) DeleteTarget {
 	if t == "" {
 		return TargetNone
 	}
+	// Resolve a leading $TMPDIR into the path the shell will really act on, so it
+	// is judged on where it points rather than on its name. When TMPDIR is unset
+	// the operand is left alone and falls through to the unresolved-variable guard
+	// below — `rm -rf $TMPDIR/x` is `rm -rf /x` on such a machine, not scratch.
+	t = expandTmpdir(t)
+
 	// Strip a single trailing slash for comparison, but remember it existed.
 	bare := strings.TrimSuffix(t, "/")
 
@@ -765,23 +772,24 @@ func classifyTarget(target, cwd string) DeleteTarget {
 		return TargetSensitive
 	}
 
-	// Scratch space inside a temp directory, checked once the sensitive roots are
-	// ruled out: throwaway by definition, and the least sensitive class there is.
-	if isUnderTempDir(t) {
-		return TargetTemp
-	}
-
 	// A path *under* home (e.g. ~/.cache, $HOME/work) — escapes the workspace.
 	if strings.HasPrefix(t, "~/") || strings.HasPrefix(t, "$HOME/") || strings.HasPrefix(t, "${HOME}/") {
 		return TargetOutsideWorkspace
 	}
 
-	// Absolute paths: inside cwd is workspace-relative, otherwise outside.
+	// Absolute paths: inside cwd is workspace-relative, otherwise scratch space if
+	// it sits under a temp directory, otherwise outside the workspace. Containment
+	// in cwd is checked first so that a workspace which itself lives under /tmp
+	// still classifies its own files as workspace-local — temp ranks below
+	// cwd-relative on the scale, and the ordering here has to agree.
 	if strings.HasPrefix(t, "/") {
 		if cwd != "" {
 			if rel, err := filepath.Rel(cwd, t); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 				return TargetCwdRelative
 			}
+		}
+		if isUnderTempDir(t) {
+			return TargetTemp
 		}
 		return TargetOutsideWorkspace
 	}
@@ -804,10 +812,45 @@ func classifyTarget(target, cwd string) DeleteTarget {
 // tempRoots are the directories whose contents are scratch space. The macOS
 // /private/* forms are the real paths behind /tmp and /var/tmp, which a tool
 // resolving symlinks will hand us instead of the short form.
+//
+// $TMPDIR is deliberately absent: it is resolved to its value by expandTmpdir
+// before classification, so what lands here is always a concrete path.
 var tempRoots = []string{
 	"/tmp", "/var/tmp",
 	"/private/tmp", "/private/var/tmp",
-	"$TMPDIR", "${TMPDIR}",
+}
+
+// tmpdirForms are the shell spellings of the TMPDIR variable that expandTmpdir
+// recognises. Only a whole-segment match counts, so $TMPDIRX stays unresolved.
+var tmpdirForms = []string{"${TMPDIR}", "$TMPDIR"}
+
+// expandTmpdir rewrites a leading $TMPDIR / ${TMPDIR} into the value the shell
+// would expand it to, so the operand can be judged on where it actually points.
+//
+// Trusting the spelling alone fails open: on a machine with TMPDIR unset the
+// shell expands `rm -rf $TMPDIR/scratch` to `rm -rf /scratch`, a root-level
+// delete. When TMPDIR is unset, empty, or not absolute, the operand is returned
+// untouched so the caller's unresolved-variable guard classifies it as outside
+// the workspace and the user gets a prompt — the right answer for a variable we
+// cannot resolve. Reading the environment is safe here: fence is spawned by the
+// agent that will run the command, so it inherits the same TMPDIR the shell sees.
+func expandTmpdir(t string) string {
+	for _, form := range tmpdirForms {
+		rest, ok := strings.CutPrefix(t, form)
+		if !ok {
+			continue
+		}
+		// $TMPDIRX and ${TMPDIR}x name something else entirely.
+		if rest != "" && !strings.HasPrefix(rest, "/") {
+			continue
+		}
+		val := os.Getenv("TMPDIR")
+		if !strings.HasPrefix(val, "/") {
+			return t
+		}
+		return path.Clean(val + "/" + rest)
+	}
+	return t
 }
 
 // macTempFolderRe matches the per-user temp directory macOS puts $TMPDIR in

--- a/internal/analyzer/shell/shell.go
+++ b/internal/analyzer/shell/shell.go
@@ -9,6 +9,7 @@
 package shell
 
 import (
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -24,11 +25,16 @@ type DeleteTarget int
 const (
 	// TargetNone means no target was found.
 	TargetNone DeleteTarget = iota
+	// TargetTemp is a path *inside* a system temp directory (/tmp/build-x,
+	// $TMPDIR/cache). Agents create and clear scratch space constantly and the
+	// blast radius is throwaway data, so these rank below workspace-local paths
+	// on the severity scale and must not prompt.
+	TargetTemp
 	// TargetCwdRelative is a path inside the current workspace (e.g. ./dist,
 	// node_modules, *). These are everyday operations and must not be blocked.
 	TargetCwdRelative
 	// TargetOutsideWorkspace is a path that escapes the workspace but is not a
-	// well-known sensitive root (e.g. ~/.cache/foo, /tmp/x, ../sibling).
+	// well-known sensitive root (e.g. ~/.cache/foo, /tmp itself, ../sibling).
 	TargetOutsideWorkspace
 	// TargetSensitive is a home/root/system root (~, $HOME, /, /*). Touching
 	// these destructively is almost never intentional from an agent.
@@ -37,6 +43,8 @@ const (
 
 func (t DeleteTarget) String() string {
 	switch t {
+	case TargetTemp:
+		return "temp"
 	case TargetCwdRelative:
 		return "cwd_relative"
 	case TargetOutsideWorkspace:
@@ -757,6 +765,12 @@ func classifyTarget(target, cwd string) DeleteTarget {
 		return TargetSensitive
 	}
 
+	// Scratch space inside a temp directory, checked once the sensitive roots are
+	// ruled out: throwaway by definition, and the least sensitive class there is.
+	if isUnderTempDir(t) {
+		return TargetTemp
+	}
+
 	// A path *under* home (e.g. ~/.cache, $HOME/work) — escapes the workspace.
 	if strings.HasPrefix(t, "~/") || strings.HasPrefix(t, "$HOME/") || strings.HasPrefix(t, "${HOME}/") {
 		return TargetOutsideWorkspace
@@ -785,6 +799,67 @@ func classifyTarget(target, cwd string) DeleteTarget {
 
 	// Everything else (., ./build, node_modules, *, dist/) is workspace-local.
 	return TargetCwdRelative
+}
+
+// tempRoots are the directories whose contents are scratch space. The macOS
+// /private/* forms are the real paths behind /tmp and /var/tmp, which a tool
+// resolving symlinks will hand us instead of the short form.
+var tempRoots = []string{
+	"/tmp", "/var/tmp",
+	"/private/tmp", "/private/var/tmp",
+	"$TMPDIR", "${TMPDIR}",
+}
+
+// macTempFolderRe matches the per-user temp directory macOS puts $TMPDIR in
+// (/var/folders/<hash>/<hash>/T), optionally via its /private real path. The
+// sibling C directory under the same prefix is the user's cache, not scratch,
+// so the trailing /T is required.
+var macTempFolderRe = regexp.MustCompile(`^(/private)?/var/folders/[^/]+/[^/]+/T(/|$)`)
+
+// isUnderTempDir reports whether target names a path *inside* a temp directory.
+//
+// The temp root itself is deliberately excluded: `rm -rf /tmp` and the bare
+// wildcard sweep `rm -rf /tmp/*` wipe every process's scratch state (and on
+// macOS /tmp is a system symlink), which is exactly the ambiguous case worth a
+// prompt. A prefixed glob like /tmp/build-* still names a specific target, so it
+// qualifies. The path is cleaned first, so a traversal that escapes the root
+// (/tmp/../etc, which is really /etc) loses the prefix and falls through to the
+// normal classification.
+func isUnderTempDir(target string) bool {
+	// path.Clean, not filepath.Clean: these are shell paths, always slash-separated.
+	cleaned := path.Clean(target)
+
+	rest, ok := afterTempRoot(cleaned)
+	if !ok {
+		return false
+	}
+	// The first segment under the root must name something specific.
+	first, _, _ := strings.Cut(rest, "/")
+	return first != "" && !isBareGlob(first)
+}
+
+// afterTempRoot strips a temp-directory prefix from a cleaned path and returns
+// the remainder. A path equal to the root itself has no remainder and so is not
+// "under" it.
+func afterTempRoot(cleaned string) (string, bool) {
+	for _, root := range tempRoots {
+		if rest, ok := strings.CutPrefix(cleaned, root+"/"); ok {
+			return rest, true
+		}
+	}
+	if loc := macTempFolderRe.FindString(cleaned); strings.HasSuffix(loc, "/") {
+		return cleaned[len(loc):], true
+	}
+	return "", false
+}
+
+// isBareGlob reports whether a path segment is nothing but wildcards (*, **, ?)
+// — a sweep of the whole directory rather than a named target.
+func isBareGlob(segment string) bool {
+	if segment == "" {
+		return false
+	}
+	return strings.Trim(segment, "*?") == ""
 }
 
 // isNetToShellPipe reports whether a pipeline routes a network fetcher into a

--- a/internal/analyzer/shell/shell_test.go
+++ b/internal/analyzer/shell/shell_test.go
@@ -1,9 +1,16 @@
 package shell
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
 
 func TestRecursiveDeleteClassification(t *testing.T) {
 	const cwd = "/Users/dev/project"
+
+	// $TMPDIR is resolved against the environment, so pin it rather than
+	// inheriting whatever the machine running the tests happens to have.
+	t.Setenv("TMPDIR", "/tmp")
 
 	cases := []struct {
 		name      string
@@ -89,6 +96,96 @@ func TestRecursiveDeleteClassification(t *testing.T) {
 			}
 			if a.RecursiveDelete != tc.recursive {
 				t.Errorf("RecursiveDelete = %v, want %v", a.RecursiveDelete, tc.recursive)
+			}
+			if a.DeleteTarget != tc.target {
+				t.Errorf("DeleteTarget = %v, want %v", a.DeleteTarget, tc.target)
+			}
+		})
+	}
+}
+
+// TestTmpdirResolution pins the fail-closed handling of $TMPDIR. Trusting the
+// spelling would be a hole: with TMPDIR unset the shell expands
+// `rm -rf $TMPDIR/scratch` to `rm -rf /scratch`, which is not scratch space at
+// all, so anything we cannot resolve to a real temp directory must still prompt.
+func TestTmpdirResolution(t *testing.T) {
+	const cwd = "/Users/dev/project"
+
+	cases := []struct {
+		name    string
+		tmpdir  string
+		setEnv  bool
+		command string
+		target  DeleteTarget
+	}{
+		{"set to tmp", "/tmp", true, "rm -rf $TMPDIR/scratch", TargetTemp},
+		{"set with trailing slash", "/tmp/", true, "rm -rf $TMPDIR/scratch", TargetTemp},
+		{"set to mac per-user temp", "/var/folders/zz/9k1n_c/T", true, "rm -rf $TMPDIR/build", TargetTemp},
+		// Unset, empty, or relative: unresolvable, so ask rather than allow.
+		{"unset", "", false, "rm -rf $TMPDIR/scratch", TargetOutsideWorkspace},
+		{"empty", "", true, "rm -rf $TMPDIR/scratch", TargetOutsideWorkspace},
+		{"relative", "relative/tmp", true, "rm -rf $TMPDIR/scratch", TargetOutsideWorkspace},
+		// Pointing somewhere that is not a temp directory does not make it one.
+		{"not a temp dir", "/Users/dev/scratch", true, "rm -rf $TMPDIR/x", TargetOutsideWorkspace},
+		// Root itself stays the most severe answer however we get there.
+		{"tmpdir is root", "/", true, "rm -rf $TMPDIR", TargetSensitive},
+		// A different variable that merely starts with the same letters.
+		{"lookalike variable", "/tmp", true, "rm -rf $TMPDIRX/scratch", TargetOutsideWorkspace},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.setEnv {
+				t.Setenv("TMPDIR", tc.tmpdir)
+			} else {
+				// t.Setenv restores the previous value (including absence) on cleanup.
+				t.Setenv("TMPDIR", "")
+				if err := os.Unsetenv("TMPDIR"); err != nil {
+					t.Fatalf("unset TMPDIR: %v", err)
+				}
+			}
+			a := Analyze(tc.command, cwd)
+			if !a.Parsed {
+				t.Fatalf("command did not parse: %q", tc.command)
+			}
+			if a.DeleteTarget != tc.target {
+				t.Errorf("DeleteTarget = %v, want %v", a.DeleteTarget, tc.target)
+			}
+		})
+	}
+}
+
+// TestWorkspaceInsideTempDir pins the ordering between the temp and
+// workspace-local tiers. temp ranks below cwd-relative on the severity scale, so
+// a project that happens to live under /tmp must classify its own files as
+// workspace-local — otherwise a pack that opts into `delete_target: temp` would
+// see the workspace's own deletes as scratch.
+func TestWorkspaceInsideTempDir(t *testing.T) {
+	t.Setenv("TMPDIR", "/tmp")
+	const cwd = "/tmp/myproject"
+
+	cases := []struct {
+		name    string
+		command string
+		target  DeleteTarget
+	}{
+		// Inside the workspace: workspace-local, even though it is also under /tmp.
+		{"workspace subdir", "rm -rf /tmp/myproject/dist", TargetCwdRelative},
+		{"workspace itself", "rm -rf /tmp/myproject", TargetCwdRelative},
+		{"workspace relative", "rm -rf dist", TargetCwdRelative},
+		// A sibling under the same temp root is not part of the workspace, so it
+		// falls back to scratch space.
+		{"sibling in temp", "rm -rf /tmp/other-agent", TargetTemp},
+		// The temp root and a bare sweep of it still ask, workspace or not.
+		{"temp root", "rm -rf /tmp", TargetOutsideWorkspace},
+		{"temp root sweep", "rm -rf /tmp/*", TargetOutsideWorkspace},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := Analyze(tc.command, cwd)
+			if !a.Parsed {
+				t.Fatalf("command did not parse: %q", tc.command)
 			}
 			if a.DeleteTarget != tc.target {
 				t.Errorf("DeleteTarget = %v, want %v", a.DeleteTarget, tc.target)

--- a/internal/analyzer/shell/shell_test.go
+++ b/internal/analyzer/shell/shell_test.go
@@ -29,8 +29,45 @@ func TestRecursiveDeleteClassification(t *testing.T) {
 
 		// Outside the workspace but not a sensitive root — should ask, not deny.
 		{"home subdir", "rm -rf ~/.cache/thing", true, TargetOutsideWorkspace},
-		{"tmp", "rm -rf /tmp/scratch", true, TargetOutsideWorkspace},
 		{"parent escape", "rm -rf ../sibling", true, TargetOutsideWorkspace},
+
+		// Scratch space inside a temp dir — MUST NOT be flagged. Agents create and
+		// clear these constantly and the blast radius is throwaway data.
+		{"tmp subdir", "rm -rf /tmp/scratch", true, TargetTemp},
+		{"tmp nested", "rm -rf /tmp/agent/build/out", true, TargetTemp},
+		{"tmp trailing slash", "rm -rf /tmp/scratch/", true, TargetTemp},
+		{"tmp prefixed glob", "rm -rf /tmp/build-*", true, TargetTemp},
+		{"tmp redundant separators", "rm -rf /tmp//agent/./out", true, TargetTemp},
+		{"var tmp", "rm -rf /var/tmp/cache", true, TargetTemp},
+		{"private tmp", "rm -rf /private/tmp/scratch", true, TargetTemp},
+		{"private var tmp", "rm -rf /private/var/tmp/scratch", true, TargetTemp},
+		{"mac tmpdir folders", "rm -rf /var/folders/zz/9k1n_c/T/build", true, TargetTemp},
+		{"mac tmpdir folders private", "rm -rf /private/var/folders/zz/9k1n_c/T/build", true, TargetTemp},
+		{"tmpdir var", "rm -rf $TMPDIR/scratch", true, TargetTemp},
+		{"tmpdir var braces", "rm -rf ${TMPDIR}/scratch", true, TargetTemp},
+		{"tmpdir var quoted", "rm -rf \"$TMPDIR\"/scratch", true, TargetTemp},
+		{"sudo tmp", "sudo rm -rf /tmp/scratch", true, TargetTemp},
+
+		// The temp root ITSELF, and a bare sweep of it, still ask: those wipe every
+		// process's scratch state rather than one named target.
+		{"tmp root", "rm -rf /tmp", true, TargetOutsideWorkspace},
+		{"tmp root slash", "rm -rf /tmp/", true, TargetOutsideWorkspace},
+		{"tmp root glob", "rm -rf /tmp/*", true, TargetOutsideWorkspace},
+		{"tmp root double glob", "rm -rf /tmp/**", true, TargetOutsideWorkspace},
+		{"tmp glob then path", "rm -rf /tmp/*/cache", true, TargetOutsideWorkspace},
+		{"var tmp root", "rm -rf /var/tmp", true, TargetOutsideWorkspace},
+		{"tmpdir root", "rm -rf $TMPDIR", true, TargetOutsideWorkspace},
+		{"tmpdir root glob", "rm -rf $TMPDIR/*", true, TargetOutsideWorkspace},
+		{"mac tmpdir root", "rm -rf /var/folders/zz/9k1n_c/T", true, TargetOutsideWorkspace},
+		// Not a temp dir despite the name, and traversal out of one.
+		{"tmp lookalike sibling", "rm -rf /tmpfoo/bar", true, TargetOutsideWorkspace},
+		{"var folders cache not temp", "rm -rf /var/folders/zz/9k1n_c/C/x", true, TargetOutsideWorkspace},
+		{"tmp traversal escapes", "rm -rf /tmp/../etc", true, TargetOutsideWorkspace},
+		{"tmp traversal to root", "rm -rf /tmp/..", true, TargetOutsideWorkspace},
+		// The most severe operand wins, so one temp path never launders another.
+		{"tmp plus home", "rm -rf /tmp/scratch ~", true, TargetSensitive},
+		{"tmp plus outside", "rm -rf /tmp/scratch ~/.cache/x", true, TargetOutsideWorkspace},
+		{"tmp plus local", "rm -rf /tmp/scratch node_modules", true, TargetCwdRelative},
 
 		// Everyday operations — MUST NOT be flagged (no false positives).
 		{"node_modules", "rm -rf node_modules", true, TargetCwdRelative},
@@ -265,7 +302,7 @@ func TestChmodFacts(t *testing.T) {
 		{"a+rwx home", "chmod -R a+rwx $HOME", true, TargetSensitive},
 		// World-writable elsewhere.
 		{"777 etc passwd", "chmod 777 /etc/passwd", true, TargetOutsideWorkspace},
-		{"666 tmp", "chmod 666 /tmp/x", true, TargetOutsideWorkspace},
+		{"666 tmp", "chmod 666 /tmp/x", true, TargetTemp},
 		{"777 local file", "chmod 777 ./script.sh", true, TargetCwdRelative},
 		{"o+w local", "chmod o+w config.yaml", true, TargetCwdRelative},
 		{"combined flags then mode", "chmod -Rv 777 build", true, TargetCwdRelative},

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -234,7 +234,7 @@ func matchShell(m *ShellMatch, a *shell.Analysis) bool {
 }
 
 // targetMatches reports whether a path-severity spec
-// (sensitive|outside_workspace|any) is satisfied by the analyzed target.
+// (sensitive|outside_workspace|temp|any) is satisfied by the analyzed target.
 // Unknown specs are rejected at load time, so they pass here.
 func targetMatches(spec string, t shell.DeleteTarget) bool {
 	switch spec {
@@ -244,6 +244,8 @@ func targetMatches(spec string, t shell.DeleteTarget) bool {
 		return t == shell.TargetSensitive
 	case "outside_workspace":
 		return t == shell.TargetOutsideWorkspace
+	case "temp":
+		return t == shell.TargetTemp
 	}
 	return true
 }

--- a/internal/policy/engine_test.go
+++ b/internal/policy/engine_test.go
@@ -14,6 +14,10 @@ func TestRecommendedShellDecisions(t *testing.T) {
 	e := recommendedEngine(t)
 	const cwd = "/Users/dev/project"
 
+	// $TMPDIR resolves against the environment, so pin it rather than depending on
+	// what the machine running the tests happens to set (Linux often sets nothing).
+	t.Setenv("TMPDIR", "/tmp")
+
 	cases := []struct {
 		command string
 		want    Effect
@@ -106,6 +110,26 @@ func TestRecommendedInstallDecisions(t *testing.T) {
 				t.Errorf("deciding rule = %q, want %q", gotRule, tc.rule)
 			}
 		})
+	}
+}
+
+// TestRecommendedTmpdirUnsetAsks pins the end-to-end consequence of an unset
+// TMPDIR: the shell expands `rm -rf $TMPDIR/scratch` to `rm -rf /scratch`, so
+// the scratch-space allowance must not apply and the user must still be asked.
+func TestRecommendedTmpdirUnsetAsks(t *testing.T) {
+	e := recommendedEngine(t)
+	// t.Setenv registers the restore; Unsetenv then removes the variable outright.
+	t.Setenv("TMPDIR", "")
+	if err := os.Unsetenv("TMPDIR"); err != nil {
+		t.Fatalf("unset TMPDIR: %v", err)
+	}
+
+	d := e.Evaluate(Action{Kind: ActionShell, Command: "rm -rf $TMPDIR/scratch", Cwd: "/Users/dev/project"})
+	if d.Effect != EffectAsk {
+		t.Fatalf("effect = %v, want %v", d.Effect, EffectAsk)
+	}
+	if d.Rule == nil || d.Rule.ID != "destructive-delete-outside-workspace" {
+		t.Errorf("deciding rule = %v, want destructive-delete-outside-workspace", d.Rule)
 	}
 }
 

--- a/internal/policy/engine_test.go
+++ b/internal/policy/engine_test.go
@@ -31,6 +31,19 @@ func TestRecommendedShellDecisions(t *testing.T) {
 		{"git push --force", EffectAsk, "git-force-push"},
 		{"git reset --hard HEAD~2", EffectAsk, "git-destructive-history"},
 
+		// Clearing scratch space in a temp dir -> allow. Agents do this constantly;
+		// prompting every time is the false positive that gets Fence uninstalled.
+		{"rm -rf /tmp/agent-build", EffectAllow, ""},
+		{"rm -rf /var/tmp/cache", EffectAllow, ""},
+		{"rm -rf $TMPDIR/scratch", EffectAllow, ""},
+		{"rm -rf /var/folders/zz/9k1n_c/T/build", EffectAllow, ""},
+		// ...but the temp root itself, and a bare sweep of it, still ask.
+		{"rm -rf /tmp", EffectAsk, "destructive-delete-outside-workspace"},
+		{"rm -rf /tmp/*", EffectAsk, "destructive-delete-outside-workspace"},
+		{"rm -rf $TMPDIR/*", EffectAsk, "destructive-delete-outside-workspace"},
+		// A temp operand never launders a dangerous one alongside it.
+		{"rm -rf /tmp/scratch ~", EffectDeny, "destructive-delete-sensitive"},
+
 		// Everyday operations -> allow (no false positives).
 		{"rm -rf node_modules", EffectAllow, ""},
 		{"rm -rf ./dist", EffectAllow, ""},

--- a/internal/policy/rule.go
+++ b/internal/policy/rule.go
@@ -63,9 +63,9 @@ type Match struct {
 // ShellMatch matches against facts produced by the shell analyzer.
 type ShellMatch struct {
 	RecursiveDelete    bool     `yaml:"recursive_delete,omitempty"`
-	DeleteTarget       string   `yaml:"delete_target,omitempty"` // sensitive|outside_workspace|any
+	DeleteTarget       string   `yaml:"delete_target,omitempty"` // sensitive|outside_workspace|temp|any
 	ChmodWorldWritable bool     `yaml:"chmod_world_writable,omitempty"`
-	ChmodTarget        string   `yaml:"chmod_target,omitempty"` // sensitive|outside_workspace|any
+	ChmodTarget        string   `yaml:"chmod_target,omitempty"` // sensitive|outside_workspace|temp|any
 	BlockDeviceWrite   bool     `yaml:"block_device_write,omitempty"`
 	ForcePush          bool     `yaml:"force_push,omitempty"`
 	HistoryRewrite     bool     `yaml:"history_rewrite,omitempty"`
@@ -137,7 +137,7 @@ func (r *Rule) compile() error {
 
 func validateTargetSpec(ruleID, field, spec string) error {
 	switch spec {
-	case "", "sensitive", "outside_workspace", "any":
+	case "", "sensitive", "outside_workspace", "temp", "any":
 		return nil
 	default:
 		return fmt.Errorf("rule %q has invalid %s %q", ruleID, field, spec)


### PR DESCRIPTION
## Problem

Every `rm -rf /tmp/...` was hitting `destructive-delete-outside-workspace` and prompting. Agents create and clear scratch space constantly, so this fired all day on throwaway data — exactly the false positive that gets a guardrail uninstalled.

`classifyTarget` had no notion of a temp directory: any absolute path outside cwd became `TargetOutsideWorkspace`.

## Change

A new `TargetTemp` on the shared path-severity scale, slotted **below** `TargetCwdRelative`. Nothing in the recommended pack matches it, so scratch deletes fall through to the default `allow` — no new rule needed.

Roots covered: `/tmp`, `/var/tmp`, the macOS `/private` real paths for both, the `/var/folders/<hash>/<hash>/T` directory macOS puts `$TMPDIR` in, and the literal `$TMPDIR` / `${TMPDIR}` forms.

## What still asks

The temp **root itself** and a bare sweep of it stay `outside_workspace`, because those wipe every process's scratch state rather than one named target:

| Command | Before | After |
|---|---|---|
| `rm -rf /tmp/agent-scratch` | ⚠️ ask | ✅ allow |
| `rm -rf $TMPDIR/build` | ⚠️ ask | ✅ allow |
| `rm -rf /var/tmp/x` | ⚠️ ask | ✅ allow |
| `rm -rf /var/folders/zz/abc/T/build` | ⚠️ ask | ✅ allow |
| `rm -rf /tmp/build-*` (prefixed glob) | ⚠️ ask | ✅ allow |
| `rm -rf /tmp` | ⚠️ ask | ⚠️ ask |
| `rm -rf /tmp/*` | ⚠️ ask | ⚠️ ask |
| `rm -rf $TMPDIR/*` | ⚠️ ask | ⚠️ ask |
| `rm -rf /tmp/scratch ~` | 🛑 deny | 🛑 deny |

The `$TMPDIR/*` exclusion is load-bearing: with the variable unset that expands to `rm -rf /*`.

## Safety details

- **Traversal.** Targets are `path.Clean`ed before the prefix test, so `/tmp/../etc` loses the temp prefix and falls through to the normal, stricter classification.
- **Lookalikes.** `/tmpfoo/bar` does not match; `/var/folders/.../C/x` (the macOS *cache* sibling) does not match — the trailing `/T` is required.
- **Mixed operands.** The scale is shared and the most severe operand wins, so one temp path never launders a dangerous one beside it.
- **chmod is unchanged.** `chmod_target` uses the same scale, but `chmod-world-writable` has no target constraint, so `chmod 777 /tmp/x` still asks.

`temp` is also exposed as a matchable spec (`delete_target: temp`), so a pack can opt back into prompting.

## Verification

- `go test ./...`, `go vet ./...`, `gofmt -l .` all clean.
- 24 new table-driven cases in `shell_test.go` pinning both the catch and the false-positive guards, plus 8 end-to-end decision cases in `engine_test.go`.
- Live-checked through the built binary and through `fence hook claude-code` (the real agent path), not just the test suite.

## Docs

README (feature bullet, behavior table, a paragraph on the exception), `docs/rules.md` (a value table for the shared scale + an opt-back-in snippet), and CLAUDE.md's false-positive discipline list.
